### PR TITLE
Scripted subscriber consumer

### DIFF
--- a/reactor-test/src/main/java/reactor/test/subscriber/DefaultScriptedSubscriberBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/subscriber/DefaultScriptedSubscriberBuilder.java
@@ -106,19 +106,13 @@ class DefaultScriptedSubscriberBuilder<T> implements ScriptedSubscriber.ValueBui
 
 	@Override
 	public ScriptedSubscriber.ValueBuilder<T> expectValueWith(Predicate<T> predicate) {
-		return expectValueWith(predicate, t -> String.format("predicate failed on value: %s", t));
-	}
-
-	@Override
-	public ScriptedSubscriber.ValueBuilder<T> expectValueWith(Predicate<T> predicate,
-			Function<T, String> assertionMessage) {
 
 		SignalEvent<T> event = new SignalEvent<>(signal -> {
 			if (!signal.isOnNext()) {
 				return Optional.of(String.format("expected: onNext(); actual: %s", signal));
 			}
 			else if (!predicate.test(signal.get())) {
-				return Optional.of(assertionMessage.apply(signal.get()));
+				return Optional.of(String.format("predicate failed on value: %s", signal.get()));
 			}
 			else {
 				return Optional.empty();
@@ -185,20 +179,14 @@ class DefaultScriptedSubscriberBuilder<T> implements ScriptedSubscriber.ValueBui
 
 	@Override
 	public ScriptedSubscriber<T> expectErrorWith(Predicate<Throwable> predicate) {
-		return expectErrorWith(predicate,
-				t -> String.format("predicate failed on exception: %s", t));
-	}
-
-	@Override
-	public ScriptedSubscriber<T> expectErrorWith(Predicate<Throwable> predicate,
-			Function<Throwable, String> assertionMessage) {
 
 		SignalEvent<T> event = new SignalEvent<>(signal -> {
 			if (!signal.isOnError()) {
 				return Optional.of(String.format("expected: onError(); actual: %s", signal));
 			}
 			else if (!predicate.test(signal.getThrowable())) {
-				return Optional.of(assertionMessage.apply(signal.getThrowable()));
+				return Optional.of(String.format("predicate failed on exception: %s",
+						signal.getThrowable()));
 			}
 			else {
 				return Optional.empty();

--- a/reactor-test/src/main/java/reactor/test/subscriber/ScriptedSubscriber.java
+++ b/reactor-test/src/main/java/reactor/test/subscriber/ScriptedSubscriber.java
@@ -18,6 +18,7 @@ package reactor.test.subscriber;
 
 import java.time.Duration;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -167,6 +168,14 @@ public interface ScriptedSubscriber<T> extends Subscriber<T> {
 				Function<Throwable, String> assertionMessage);
 
 		/**
+		 * Expect an error and consume with the given consumer. Any {@code AssertionError}s
+		 * thrown by the consumer will be rethrown during {@linkplain #verify() verification}.
+		 * @param consumer the consumer for the exception
+		 * @return the built subscriber
+		 */
+		ScriptedSubscriber<T> consumeErrorWith(Consumer<Throwable> consumer);
+
+		/**
 		 * Expect the completion signal.
 		 * @return the built subscriber
 		 * @see Subscriber#onComplete()
@@ -234,5 +243,13 @@ public interface ScriptedSubscriber<T> extends Subscriber<T> {
 		 */
 		ValueBuilder<T> expectValueWith(Predicate<T> predicate,
 				Function<T, String> assertionMessage);
+
+		/**
+		 * Expect an element and consume with the given consumer. Any {@code AssertionError}s
+		 * thrown by the consumer will be rethrown during {@linkplain #verify() verification}.
+		 * @param consumer the consumer for the value
+		 * @return this builder
+		 */
+		ValueBuilder<T> consumeValueWith(Consumer<T> consumer);
 	}
 }

--- a/reactor-test/src/main/java/reactor/test/subscriber/ScriptedSubscriber.java
+++ b/reactor-test/src/main/java/reactor/test/subscriber/ScriptedSubscriber.java
@@ -19,7 +19,6 @@ package reactor.test.subscriber;
 import java.time.Duration;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.reactivestreams.Subscriber;
@@ -156,18 +155,6 @@ public interface ScriptedSubscriber<T> extends Subscriber<T> {
 		ScriptedSubscriber<T> expectErrorWith(Predicate<Throwable> predicate);
 
 		/**
-		 * Expect an error and evaluate with the given predicate. The given
-		 * {@code assertionMessage} function is used to create the {@code AssertionError} message,
-		 * if the expectation failed.
-		 * @param predicate the predicate to test on the next received error
-		 * @param assertionMessage supplies the exception message
-		 * @return the built subscriber
-		 * @see Subscriber#onError(Throwable)
-		 */
-		ScriptedSubscriber<T> expectErrorWith(Predicate<Throwable> predicate,
-				Function<Throwable, String> assertionMessage);
-
-		/**
 		 * Expect an error and consume with the given consumer. Any {@code AssertionError}s
 		 * thrown by the consumer will be rethrown during {@linkplain #verify() verification}.
 		 * @param consumer the consumer for the exception
@@ -231,18 +218,6 @@ public interface ScriptedSubscriber<T> extends Subscriber<T> {
 		 * @see Subscriber#onNext(Object)
 		 */
 		ValueBuilder<T> expectValueWith(Predicate<T> predicate);
-
-		/**
-		 * Expect an element and evaluate with the given predicate. The given
-		 * {@code assertionMessage} function is used to create the {@code AssertionError} message,
-		 * if the expectation failed.
-		 * @param predicate the predicate to test on the next received value
-		 * @param assertionMessage supplies the exception message
-		 * @return this builder
-		 * @see Subscriber#onNext(Object)
-		 */
-		ValueBuilder<T> expectValueWith(Predicate<T> predicate,
-				Function<T, String> assertionMessage);
 
 		/**
 		 * Expect an element and consume with the given consumer. Any {@code AssertionError}s

--- a/reactor-test/src/test/java/reactor/test/subscriber/ScriptedSubscriberIntegrationTests.java
+++ b/reactor-test/src/test/java/reactor/test/subscriber/ScriptedSubscriberIntegrationTests.java
@@ -122,23 +122,6 @@ public class ScriptedSubscriberIntegrationTests {
 	}
 
 	@Test
-	public void expectValueWithCustomMessage() throws InterruptedException {
-		ScriptedSubscriber<String> subscriber = ScriptedSubscriber.<String>create()
-				.expectValueWith("foo"::equals, s -> s)
-				.expectComplete();
-
-		Flux<String> flux = Flux.just("bar");
-		flux.subscribe(subscriber);
-
-		try {
-			subscriber.verify();
-		}
-		catch (AssertionError error) {
-			assertEquals("Expectation failure(s):\n - bar", error.getMessage());
-		}
-	}
-
-	@Test
 	public void consumeValueWith() throws Exception {
 		ScriptedSubscriber<String> subscriber = ScriptedSubscriber.<String>create()
 				.consumeValueWith(s -> {
@@ -240,24 +223,6 @@ public class ScriptedSubscriberIntegrationTests {
 		flux.subscribe(subscriber);
 
 		subscriber.verify();
-	}
-
-	@Test
-	public void errorWithCustomMessage() throws InterruptedException {
-		ScriptedSubscriber<String> subscriber = ScriptedSubscriber.<String>create()
-				.expectValue("foo")
-				.expectErrorWith(t -> t instanceof IllegalStateException,
-						throwable -> throwable.getClass().getSimpleName());
-
-		Flux<String> flux = Flux.just("foo").concatWith(Mono.error(new IllegalArgumentException()));
-		flux.subscribe(subscriber);
-
-		try {
-			subscriber.verify();
-		}
-		catch (AssertionError error) {
-			assertEquals("Expectation failure(s):\n - IllegalArgumentException", error.getMessage());
-		}
 	}
 
 	@Test


### PR DESCRIPTION
Two changes to `ScriptedSubscriber`:

 - Added consumer-based variants, as requested by @bclozel and @nebhale 
- Removed `<Predicate, Function>` expect variants, since they typically required code duplication