### PR TITLE
Delay verification until completion

### DIFF
--- a/reactor-test/src/main/java/reactor/test/subscriber/DefaultScriptedSubscriberBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/subscriber/DefaultScriptedSubscriberBuilder.java
@@ -335,14 +335,14 @@ class DefaultScriptedSubscriberBuilder<T> implements ScriptedSubscriber.ValueBui
 
 		@Override
 		public void verify() {
-			if (this.subscription.get() == null) {
-				throw new IllegalStateException("ScriptedSubscriber has not been subscribed");
-			}
 			try {
 				this.completeLatch.await();
 			}
 			catch (InterruptedException ex) {
 				Thread.currentThread().interrupt();
+			}
+			if (this.subscription.get() == null) {
+				throw new IllegalStateException("ScriptedSubscriber has not been subscribed");
 			}
 			verifyInternal();
 		}
@@ -355,17 +355,22 @@ class DefaultScriptedSubscriberBuilder<T> implements ScriptedSubscriber.ValueBui
 
 		@Override
 		public void verify(Duration duration) {
-			if (this.subscription.get() == null) {
-				throw new IllegalStateException("ScriptedSubscriber has not been subscribed");
-			}
 			try {
 				if (!this.completeLatch.await(duration.toMillis(), TimeUnit.MILLISECONDS)) {
-					throw new AssertionError("ScriptedSubscriber timed out on " +
-							this.subscription.get());
+					if (this.subscription.get() == null) {
+						throw new IllegalStateException("ScriptedSubscriber has not been subscribed");
+					}
+					else {
+						throw new AssertionError("ScriptedSubscriber timed out on " +
+								this.subscription.get());
+					}
 				}
 			}
 			catch (InterruptedException ex) {
 				Thread.currentThread().interrupt();
+			}
+			if (this.subscription.get() == null) {
+				throw new IllegalStateException("ScriptedSubscriber has not been subscribed");
 			}
 			verifyInternal();
 		}

--- a/reactor-test/src/test/java/reactor/test/subscriber/ScriptedSubscriberIntegrationTests.java
+++ b/reactor-test/src/test/java/reactor/test/subscriber/ScriptedSubscriberIntegrationTests.java
@@ -253,7 +253,7 @@ public class ScriptedSubscriberIntegrationTests {
 		ScriptedSubscriber.create()
 				.expectValue("foo")
 				.expectComplete()
-				.verify();
+				.verify(Duration.ofMillis(100));
 	}
 
 	@Test


### PR DESCRIPTION
While using `ScriptedSubscriber` with publishers involving network
latency, I've found that existing tests started to fail.

It seems the current implementation of `ScriptedSubscriber` relies
on the `Publisher` under test to send the `onSubscribe` signal
right after subscription, whereas that signal can be sent after
some delay according to the reactive streams spec.

This commit delays all verifications after completion of the
publisher under test, including if the subscriber has been
subscribed.