### PR TITLE
Initialize TestScheduler support

### DIFF
--- a/reactor-test/src/main/java/reactor/test/scheduler/TestScheduler.java
+++ b/reactor-test/src/main/java/reactor/test/scheduler/TestScheduler.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.test.scheduler;
+
+import java.util.Queue;
+import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
+import reactor.core.Cancellation;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+import reactor.core.scheduler.TimedScheduler;
+import reactor.util.concurrent.QueueSupplier;
+
+/**
+ *
+ *
+ */
+public class TestScheduler implements TimedScheduler {
+
+	/**
+	 * @return a new {@link TestScheduler}
+	 */
+	public static TestScheduler create() {
+		return new TestScheduler();
+	}
+
+	/**
+	 * Assign a singleton {@link TestScheduler} to all or timed-only {@link
+	 * Schedulers.Factory} factories. While the method is thread safe, its usually advised
+	 * to execute such wide-impact BEFORE all tested code runs (setup etc).
+	 *
+	 * @param allSchedulers true if all {@link Schedulers.Factory} factories
+	 */
+	public static void enable(boolean allSchedulers) {
+		TestScheduler s = new TestScheduler();
+		if (allSchedulers) {
+			Schedulers.setFactory(new TimedOnlyFactory(s));
+		}
+		else {
+			Schedulers.setFactory(new AllFactory(s));
+		}
+	}
+
+	/**
+	 * The current {@link TestScheduler} assigned in {@link Schedulers}
+	 * @return current {@link TestScheduler} assigned in {@link Schedulers}
+	 * @throws IllegalStateException if no {@link TestScheduler} has been found
+	 */
+	public static TestScheduler get(){
+		Scheduler s = Schedulers.newSingle("");
+		if(s instanceof TestScheduler){
+			@SuppressWarnings("unchecked")
+			TestScheduler _s = (TestScheduler)s;
+			return _s;
+		}
+		throw new IllegalStateException("A TestScheduler has noot been returned from " +
+				"Schedulers#timer, check if TestScheduler#enable has been invoked first" +
+				": "+s);
+	}
+
+	/**
+	 * Re-assign the default Reactor Core {@link Schedulers} factories.
+	 * While the method is thread safe, its usually advised to execute such wide-impact
+	 * AFTER all tested code has been run (teardown etc).
+	 */
+	public static void reset() {
+		Schedulers.resetFactory();
+	}
+
+	final Queue<TimedRunnable> queue =
+			new PriorityBlockingQueue<>(QueueSupplier.XS_BUFFER_SIZE);
+
+	volatile long counter;
+	volatile long nanoTime;
+
+	protected TestScheduler() {
+	}
+
+	/**
+	 * Triggers any tasks that have not yet been executed and that are scheduled to be
+	 * executed at or before this {@link TestScheduler}'s present time.
+	 */
+	public void advanceTime() {
+		advanceTime(nanoTime);
+	}
+
+	/**
+	 * Moves the {@link TestScheduler}'s clock forward by a specified amount of time.
+	 *
+	 * @param delayTime the amount of time to move the {@link TestScheduler}'s clock forward
+	 * @param unit the units of time that {@code delayTime} is expressed in
+	 */
+	public void advanceTimeBy(long delayTime, TimeUnit unit) {
+		advanceTimeTo(nanoTime + unit.toNanos(delayTime), TimeUnit.NANOSECONDS);
+	}
+
+	/**
+	 * Moves the {@link TestScheduler}'s clock to a particular moment in time.
+	 *
+	 * @param delayTime the point in time to move the {@link TestScheduler}'s clock to
+	 * @param unit the units of time that {@code delayTime} is expressed in
+	 */
+	public void advanceTimeTo(long delayTime, TimeUnit unit) {
+		long targetTime = unit.toNanos(delayTime);
+		advanceTime(targetTime);
+	}
+
+	@Override
+	public TimedWorker createWorker() {
+		return new TestWorker();
+	}
+
+	@Override
+	public long now(TimeUnit unit) {
+		return unit.convert(nanoTime, TimeUnit.NANOSECONDS);
+	}
+
+	@Override
+	public Cancellation schedule(Runnable task) {
+		return createWorker().schedule(task);
+	}
+
+	@Override
+	public Cancellation schedule(Runnable task, long delay, TimeUnit unit) {
+		return createWorker().schedule(task, delay, unit);
+	}
+
+	@Override
+	public Cancellation schedulePeriodically(Runnable task,
+			long initialDelay,
+			long period,
+			TimeUnit unit) {
+		return createWorker().schedulePeriodically(task, initialDelay, period, unit);
+	}
+
+	final void advanceTime(long targetTimeInNanoseconds) {
+		while (!queue.isEmpty()) {
+			TimedRunnable current = queue.peek();
+			if (current.time > targetTimeInNanoseconds) {
+				break;
+			}
+			// if scheduled time is 0 (immediate) use current virtual time
+			nanoTime = current.time == 0 ? nanoTime : current.time;
+			queue.remove();
+
+			// Only execute if not unsubscribed
+			if (!current.scheduler.shutdown) {
+				current.run.run();
+			}
+		}
+		nanoTime = targetTimeInNanoseconds;
+	}
+
+	static final class TimedRunnable implements Comparable<TimedRunnable> {
+
+		final long       time;
+		final Runnable   run;
+		final TestWorker scheduler;
+		final long       count; // for differentiating tasks at same time
+
+		TimedRunnable(TestWorker scheduler, long time, Runnable run, long count) {
+			this.time = time;
+			this.run = run;
+			this.scheduler = scheduler;
+			this.count = count;
+		}
+
+		@Override
+		public int compareTo(TimedRunnable o) {
+			if (time == o.time) {
+				return compare(count, o.count);
+			}
+			return compare(time, o.time);
+		}
+
+		static int compare(long a, long b){
+			return a < b ? -1 : (a > b ? 1 : 0);
+		}
+	}
+
+	static final class TimedOnlyFactory implements Schedulers.Factory {
+
+		final TestScheduler s;
+
+		public TimedOnlyFactory(TestScheduler s) {
+			this.s = s;
+		}
+
+		@Override
+		public TimedScheduler newTimer(ThreadFactory threadFactory) {
+			return s;
+		}
+	}
+
+	static final class AllFactory implements Schedulers.Factory {
+
+		final TestScheduler s;
+
+		public AllFactory(TestScheduler s) {
+			this.s = s;
+		}
+
+		@Override
+		public Scheduler newElastic(int ttlSeconds, ThreadFactory threadFactory) {
+			return s;
+		}
+
+		@Override
+		public Scheduler newParallel(int parallelism, ThreadFactory threadFactory) {
+			return s;
+		}
+
+		@Override
+		public Scheduler newSingle(ThreadFactory threadFactory) {
+			return s;
+		}
+
+		@Override
+		public TimedScheduler newTimer(ThreadFactory threadFactory) {
+			return s;
+		}
+	}
+
+	final class TestWorker implements TimedWorker {
+
+		volatile boolean shutdown;
+
+		@Override
+		public long now(TimeUnit unit) {
+			return TestScheduler.this.now(unit);
+		}
+
+		@Override
+		public Cancellation schedule(Runnable run) {
+			if (shutdown) {
+				return REJECTED;
+			}
+			final TimedRunnable timedTask = new TimedRunnable(this,
+					0,
+					run,
+					COUNTER.getAndIncrement(TestScheduler.this));
+			queue.add(timedTask);
+			return () -> queue.remove(timedTask);
+		}
+
+		@Override
+		public Cancellation schedule(Runnable run, long delayTime, TimeUnit unit) {
+			if (shutdown) {
+				return REJECTED;
+			}
+			final TimedRunnable timedTask = new TimedRunnable(this,
+					nanoTime + unit.toNanos(delayTime),
+					run,
+					COUNTER.getAndIncrement(TestScheduler.this));
+			queue.add(timedTask);
+
+			return () -> queue.remove(timedTask);
+		}
+
+		@Override
+		public Cancellation schedulePeriodically(Runnable task,
+				long initialDelay,
+				long period,
+				TimeUnit unit) {
+			return null;
+		}
+
+		@Override
+		public void shutdown() {
+			shutdown = true;
+		}
+
+	}
+
+	static final AtomicLongFieldUpdater<TestScheduler> COUNTER =
+			AtomicLongFieldUpdater.newUpdater(TestScheduler.class, "counter");
+}

--- a/reactor-test/src/main/java/reactor/test/scheduler/TestScheduler.java
+++ b/reactor-test/src/main/java/reactor/test/scheduler/TestScheduler.java
@@ -82,6 +82,7 @@ public class TestScheduler implements TimedScheduler {
 	 */
 	public static void reset() {
 		Schedulers.resetFactory();
+		Schedulers.shutdownNow();
 	}
 
 	final Queue<TimedRunnable> queue =

--- a/reactor-test/src/main/java/reactor/test/scheduler/TestScheduler.java
+++ b/reactor-test/src/main/java/reactor/test/scheduler/TestScheduler.java
@@ -50,7 +50,7 @@ public class TestScheduler implements TimedScheduler {
 	 */
 	public static void enable(boolean allSchedulers) {
 		TestScheduler s = new TestScheduler();
-		if (allSchedulers) {
+		if (!allSchedulers) {
 			Schedulers.setFactory(new TimedOnlyFactory(s));
 		}
 		else {
@@ -64,14 +64,14 @@ public class TestScheduler implements TimedScheduler {
 	 * @throws IllegalStateException if no {@link TestScheduler} has been found
 	 */
 	public static TestScheduler get(){
-		Scheduler s = Schedulers.newSingle("");
+		Scheduler s = Schedulers.newTimer("");
 		if(s instanceof TestScheduler){
 			@SuppressWarnings("unchecked")
 			TestScheduler _s = (TestScheduler)s;
 			return _s;
 		}
-		throw new IllegalStateException("A TestScheduler has noot been returned from " +
-				"Schedulers#timer, check if TestScheduler#enable has been invoked first" +
+		throw new IllegalStateException("Check if TestScheduler#enable has been invoked" +
+				" first" +
 				": "+s);
 	}
 

--- a/reactor-test/src/main/java/reactor/test/subscriber/DefaultScriptedSubscriberBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/subscriber/DefaultScriptedSubscriberBuilder.java
@@ -355,7 +355,7 @@ final class DefaultScriptedSubscriberBuilder<T>
 				if (event == null || event instanceof SignalEvent) {
 					break;
 				}
-				else if (event instanceof DefaultScriptedSubscriberBuilder.VirtualTimeEvent) {
+				else if (event instanceof VirtualTimeEvent) {
 					if (!actualSignal.isOnSubscribe()) {
 						VirtualTimeEvent<T> virtualTimeEvent =
 								(VirtualTimeEvent<T>) this.script.poll();

--- a/reactor-test/src/main/java/reactor/test/subscriber/DefaultScriptedSubscriberBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/subscriber/DefaultScriptedSubscriberBuilder.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -36,6 +37,7 @@ import java.util.stream.Stream;
 
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
+import reactor.core.Exceptions;
 import reactor.core.publisher.Operators;
 import reactor.core.publisher.Signal;
 import reactor.test.scheduler.TestScheduler;
@@ -84,15 +86,15 @@ final class DefaultScriptedSubscriberBuilder<T>
 
 	@Override
 	public ScriptedSubscriber.ValueBuilder<T> advanceTime() {
-		this.script.add(new VirtualTimeEvent<>(() -> TestScheduler.get()
-		                                                          .advanceTime()));
+		this.script.add(new TaskEvent<>(() -> TestScheduler.get()
+		                                                   .advanceTime()));
 		return this;
 	}
 
 	@Override
 	public ScriptedSubscriber.ValueBuilder<T> advanceTimeBy(Duration timeshift) {
-		this.script.add(new VirtualTimeEvent<>(() -> TestScheduler.get()
-		                                                          .advanceTimeBy(timeshift.toNanos(),
+		this.script.add(new TaskEvent<>(() -> TestScheduler.get()
+		                                                   .advanceTimeBy(timeshift.toNanos(),
 				                                                          TimeUnit.NANOSECONDS)));
 		return this;
 	}
@@ -100,8 +102,8 @@ final class DefaultScriptedSubscriberBuilder<T>
 	@Override
 	public ScriptedSubscriber.ValueBuilder<T> advanceTimeTo(Instant instant) {
 
-		this.script.add(new VirtualTimeEvent<>(() -> TestScheduler.get()
-		                                                          .advanceTimeTo(instant.toEpochMilli(),
+		this.script.add(new TaskEvent<>(() -> TestScheduler.get()
+		                                                   .advanceTimeTo(instant.toEpochMilli(),
 				                                                          TimeUnit.MILLISECONDS)));
 		return this;
 	}
@@ -271,7 +273,7 @@ final class DefaultScriptedSubscriberBuilder<T>
 	}
 
 	final ScriptedSubscriber<T> build() {
-		Queue<Event<T>> copy = new LinkedList<>(this.script);
+		Queue<Event<T>> copy = new ConcurrentLinkedQueue<>(this.script);
 		return new DefaultScriptedSubscriber<T>(copy, this.initialRequest, this.expectedValueCount);
 	}
 
@@ -340,30 +342,20 @@ final class DefaultScriptedSubscriberBuilder<T>
 
 		@SuppressWarnings("unchecked")
 		final void checkExpectation(Signal<T> actualSignal) {
-			Event<T> event = this.script.poll();
+			Event<T> event = this.script.peek();
 			if (event == null) {
 				addFailure("did not expect: %s", actualSignal);
 			}
-			else {
-				SignalEvent<T> signalEvent = (SignalEvent<T>) event;
+			else if(!(event instanceof TaskEvent)){
+				SignalEvent<T> signalEvent = (SignalEvent<T>) this.script.poll();
 				Optional<String> error = signalEvent.test(actualSignal);
 				error.ifPresent(this.failures::add);
 			}
 
 			for(;;) {
 				event = this.script.peek();
-				if (event == null || event instanceof SignalEvent) {
+				if (event == null || !(event instanceof SubscriptionEvent)) {
 					break;
-				}
-				else if (event instanceof VirtualTimeEvent) {
-					if (!actualSignal.isOnSubscribe()) {
-						VirtualTimeEvent<T> virtualTimeEvent =
-								(VirtualTimeEvent<T>) this.script.poll();
-						virtualTimeEvent.run();
-					}
-					else{
-						break;
-					}
 				}
 				else {
 					SubscriptionEvent<T> subscriptionEvent = (SubscriptionEvent<T>) this.script.poll();
@@ -378,34 +370,51 @@ final class DefaultScriptedSubscriberBuilder<T>
 
 		}
 
-		final void checkVirtualTimeEvent(){
+		@SuppressWarnings("unchecked")
+		final void pollTaskEventOrComplete(Duration timeout) throws InterruptedException {
+			Objects.requireNonNull(timeout, "timeout");
 			Event<T> event;
-			for(;;){
-				event = this.script.peek();
-				if (event == null || !(event instanceof VirtualTimeEvent)) {
+			Instant stop = Instant.now()
+			                      .plus(timeout);
+			for (; ; ) {
+				event = script.peek();
+				if (event != null && event instanceof TaskEvent) {
+					event = script.poll();
+					try {
+						((TaskEvent<T>) event).run();
+					}
+					catch (Throwable t){
+						Exceptions.throwIfFatal(t);
+						Subscription s = this.subscription.getAndSet(Operators.cancelledSubscription());
+						if(s!= null){
+							s.cancel();
+						}
+					}
+				}
+				if (this.completeLatch.await(10, TimeUnit.NANOSECONDS)) {
 					break;
 				}
-				else {
-						VirtualTimeEvent<T> virtualTimeEvent =
-								(VirtualTimeEvent<T>) this.script.poll();
-						virtualTimeEvent.run();
+				if (timeout != Duration.ZERO && stop.isBefore(Instant.now())) {
+					if (this.subscription.get() == null) {
+						throw new IllegalStateException(
+								"ScriptedSubscriber has not been subscribed");
 					}
+					else {
+						throw new AssertionError("ScriptedSubscriber timed out on " + this.subscription.get());
+					}
+				}
 			}
 		}
 
 		@Override
 		public void verify() {
-			checkVirtualTimeEvent();
 			try {
-				this.completeLatch.await();
+				pollTaskEventOrComplete(Duration.ZERO);
 			}
 			catch (InterruptedException ex) {
 				Thread.currentThread().interrupt();
 			}
-			if (this.subscription.get() == null) {
-				throw new IllegalStateException("ScriptedSubscriber has not been subscribed");
-			}
-			verifyInternal();
+			validate();
 		}
 
 		@Override
@@ -417,37 +426,25 @@ final class DefaultScriptedSubscriberBuilder<T>
 		@Override
 		public void verify(Duration duration) {
 			try {
-				if (!this.completeLatch.await(duration.toMillis(), TimeUnit.MILLISECONDS)) {
-					if (this.subscription.get() == null) {
-						throw new IllegalStateException("ScriptedSubscriber has not been subscribed");
-					}
-					else {
-						throw new AssertionError("ScriptedSubscriber timed out on " +
-								this.subscription.get());
-					}
-				}
+				pollTaskEventOrComplete(duration);
 			}
 			catch (InterruptedException ex) {
 				Thread.currentThread().interrupt();
 			}
-			if (this.subscription.get() == null) {
-				throw new IllegalStateException("ScriptedSubscriber has not been subscribed");
-			}
-			verifyInternal();
+			validate();
 		}
 
 		@Override
 		public void verify(Publisher<? extends T> publisher, Duration duration) {
 			publisher.subscribe(this);
-			checkTasks();
 			verify(duration);
 		}
 
-		final void checkTasks() {
-
-		}
-
-		final void verifyInternal() {
+		final void validate() {
+			if (this.subscription.get() == null) {
+				throw new IllegalStateException(
+						"ScriptedSubscriber has not been subscribed");
+			}
 			boolean validValueCount = hasValidValueCount();
 			if (this.failures.isEmpty() && validValueCount) {
 				return;
@@ -513,11 +510,11 @@ final class DefaultScriptedSubscriberBuilder<T>
 
 	}
 
-	static final class VirtualTimeEvent<T> extends Event<T> {
+	static final class TaskEvent<T> extends Event<T> {
 
 		final Runnable task;
 
-		public VirtualTimeEvent(Runnable task) {
+		public TaskEvent(Runnable task) {
 			this.task = task;
 		}
 

--- a/reactor-test/src/main/java/reactor/test/subscriber/ScriptedSubscriber.java
+++ b/reactor-test/src/main/java/reactor/test/subscriber/ScriptedSubscriber.java
@@ -17,12 +17,14 @@
 package reactor.test.subscriber;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+import reactor.test.scheduler.TestScheduler;
 
 /**
  * Subscriber implementation that verifies pre-defined expectations as part of its subscription.
@@ -68,9 +70,32 @@ import org.reactivestreams.Subscription;
  * </pre>
  *
  * @author Arjen Poutsma
+ * @author Stephane Maldini
  * @since 1.0
  */
 public interface ScriptedSubscriber<T> extends Subscriber<T> {
+
+	/**
+	 *
+	 */
+	static void enableVirtualTime(){
+		enableVirtualTime(false);
+	}
+
+	/**
+	 *
+	 * @param allSchedulers
+	 */
+	static void enableVirtualTime(boolean allSchedulers){
+		TestScheduler.enable(allSchedulers);
+	}
+
+	/**
+	 *
+	 */
+	static void disableVirtualTime(){
+		TestScheduler.reset();
+	}
 
 	/**
 	 * Verify the signals received by this subscriber. This method will <strong>block</strong>
@@ -200,6 +225,26 @@ public interface ScriptedSubscriber<T> extends Subscriber<T> {
 	 * @param <T> the type of values that the subscriber contains
 	 */
 	interface ValueBuilder<T> extends TerminationBuilder<T> {
+
+		/**
+		 *
+		 * @return this builder
+		 */
+		ValueBuilder<T> advanceTime();
+
+		/**
+		 *
+		 * @param timeshift
+		 * @return this builder
+		 */
+		ValueBuilder<T> advanceTimeBy(Duration timeshift);
+
+		/**
+		 *
+		 * @param instant
+		 * @return this builder
+		 */
+		ValueBuilder<T> advanceTimeTo(Instant instant);
 
 		/**
 		 * Request the given amount of elements from the upstream {@code Publisher}. This is in

--- a/reactor-test/src/test/java/reactor/test/scheduler/TestSchedulerTests.java
+++ b/reactor-test/src/test/java/reactor/test/scheduler/TestSchedulerTests.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2011-2016 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.test.scheduler;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * @author Stephane Maldini
+ */
+public class TestSchedulerTests {
+
+	@Test
+	public void allEnabled() {
+		Assert.assertFalse(Schedulers.newTimer("") instanceof TestScheduler);
+		Assert.assertFalse(Schedulers.newParallel("") instanceof TestScheduler);
+		Assert.assertFalse(Schedulers.newElastic("") instanceof TestScheduler);
+		Assert.assertFalse(Schedulers.newSingle("") instanceof TestScheduler);
+
+		TestScheduler.enable(true);
+
+		Assert.assertTrue(Schedulers.newParallel("") instanceof TestScheduler);
+		Assert.assertTrue(Schedulers.newElastic("") instanceof TestScheduler);
+		Assert.assertTrue(Schedulers.newSingle("") instanceof TestScheduler);
+		Assert.assertTrue(Schedulers.newTimer("") instanceof TestScheduler);
+
+		TestScheduler t = TestScheduler.get();
+
+		Assert.assertEquals(Schedulers.newParallel(""), t);
+		Assert.assertEquals(Schedulers.newElastic(""), t);
+		Assert.assertEquals(Schedulers.newSingle(""), t);
+		Assert.assertEquals(Schedulers.newTimer(""), t);
+	}
+
+	@Test
+	public void timerOnlyEnabled() {
+		Assert.assertFalse(Schedulers.newTimer("") instanceof TestScheduler);
+		Assert.assertFalse(Schedulers.newParallel("") instanceof TestScheduler);
+		Assert.assertFalse(Schedulers.newElastic("") instanceof TestScheduler);
+		Assert.assertFalse(Schedulers.newSingle("") instanceof TestScheduler);
+
+		TestScheduler.enable(false);
+
+		Assert.assertTrue(Schedulers.newTimer("") instanceof TestScheduler);
+		Assert.assertFalse(Schedulers.newParallel("") instanceof TestScheduler);
+		Assert.assertFalse(Schedulers.newElastic("") instanceof TestScheduler);
+		Assert.assertFalse(Schedulers.newSingle("") instanceof TestScheduler);
+
+		TestScheduler t = TestScheduler.get();
+
+		Assert.assertNotEquals(Schedulers.newParallel(""), t);
+		Assert.assertNotEquals(Schedulers.newElastic(""), t);
+		Assert.assertNotEquals(Schedulers.newSingle(""), t);
+		Assert.assertEquals(Schedulers.newTimer(""), t);
+	}
+
+	@After
+	public void cleanup() {
+		TestScheduler.reset();
+	}
+
+}

--- a/reactor-test/src/test/java/reactor/test/subscriber/ScriptedSubscriberIntegrationTests.java
+++ b/reactor-test/src/test/java/reactor/test/subscriber/ScriptedSubscriberIntegrationTests.java
@@ -19,7 +19,6 @@ package reactor.test.subscriber;
 import java.time.Duration;
 
 import org.junit.Test;
-
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -265,6 +264,21 @@ public class ScriptedSubscriberIntegrationTests {
 				.expectValue("foo")
 				.expectComplete()
 				.verify(flux, Duration.ofMillis(500));
+	}
+
+	@Test
+	public void verifyVirtualTime() {
+		ScriptedSubscriber.enableVirtualTime();
+		Mono<String> mono = Mono.delay(Duration.ofDays(2))
+		                        .map(l -> "foo");
+
+		ScriptedSubscriber.create()
+		                  .advanceTimeBy(Duration.ofDays(3))
+		                  .expectValue("foo")
+		                  .expectComplete()
+		                  .verify(mono, Duration.ofMillis(500));
+
+		ScriptedSubscriber.disableVirtualTime();
 	}
 
 	@Test(expected = AssertionError.class)

--- a/reactor-test/src/test/java/reactor/test/subscriber/ScriptedSubscriberIntegrationTests.java
+++ b/reactor-test/src/test/java/reactor/test/subscriber/ScriptedSubscriberIntegrationTests.java
@@ -271,7 +271,7 @@ public class ScriptedSubscriberIntegrationTests {
 	}
 
 	@Test
-	public void verifyVirtualTime() {
+	public void verifyVirtualTimeOnSubscribe() {
 		ScriptedSubscriber.enableVirtualTime();
 		Mono<String> mono = Mono.delay(Duration.ofDays(2))
 		                        .map(l -> "foo");
@@ -285,7 +285,7 @@ public class ScriptedSubscriberIntegrationTests {
 	}
 
 	@Test
-	public void verifyVirtualTime2() {
+	public void verifyVirtualTimeOnError() {
 		ScriptedSubscriber.enableVirtualTime();
 		Mono<String> mono = Mono.never()
 		                        .timeout(Duration.ofDays(2))
@@ -299,11 +299,11 @@ public class ScriptedSubscriberIntegrationTests {
 	}
 
 	@Test
-	public void verifyVirtualTimeAll() {
+	public void verifyVirtualTimeOnNext() {
 		ScriptedSubscriber.enableVirtualTime();
-		Flux<String> mono = Flux.just("foo", "bar", "foobar")
+		Flux<String> flux = Flux.just("foo", "bar", "foobar")
 		                        .delay(Duration.ofHours(1))
-				.log();
+		                        .log();
 
 		ScriptedSubscriber.create()
 		                  .advanceTimeBy(Duration.ofHours(1))
@@ -313,7 +313,39 @@ public class ScriptedSubscriberIntegrationTests {
 		                  .advanceTimeBy(Duration.ofHours(1))
 		                  .expectValue("foobar")
 		                  .expectComplete()
-		                  .verify(mono);
+		                  .verify(flux);
+
+	}
+
+	@Test
+	public void verifyVirtualTimeOnComplete() {
+		ScriptedSubscriber.enableVirtualTime();
+		Flux<?> flux = Flux.empty()
+		                   .delaySubscription(Duration.ofHours(1))
+		                   .log();
+
+		ScriptedSubscriber.create()
+		                  .advanceTimeBy(Duration.ofHours(1))
+		                  .expectComplete()
+		                  .verify(flux);
+
+	}
+
+	@Test
+	public void verifyVirtualTimeOnNextInterval() {
+		ScriptedSubscriber.enableVirtualTime();
+		Flux<String> flux = Flux.interval(Duration.ofSeconds(3))
+		                        .map(d -> "t" + d);
+
+		ScriptedSubscriber.create()
+		                  .advanceTimeBy(Duration.ofSeconds(3))
+		                  .expectValue("t0")
+		                  .advanceTimeBy(Duration.ofSeconds(3))
+		                  .expectValue("t1")
+		                  .advanceTimeBy(Duration.ofSeconds(3))
+		                  .expectValue("t2")
+		                  .doCancel()
+		                  .verify(flux);
 
 	}
 

--- a/reactor-test/src/test/java/reactor/test/subscriber/ScriptedSubscriberIntegrationTests.java
+++ b/reactor-test/src/test/java/reactor/test/subscriber/ScriptedSubscriberIntegrationTests.java
@@ -17,6 +17,8 @@
 package reactor.test.subscriber;
 
 import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.TimeoutException;
 
 import org.junit.Test;
 import reactor.core.publisher.Flux;
@@ -276,7 +278,22 @@ public class ScriptedSubscriberIntegrationTests {
 		                  .advanceTimeBy(Duration.ofDays(3))
 		                  .expectValue("foo")
 		                  .expectComplete()
-		                  .verify(mono, Duration.ofMillis(500));
+		                  .verify(mono);
+
+		ScriptedSubscriber.disableVirtualTime();
+	}
+
+	@Test
+	public void verifyVirtualTime2() {
+		ScriptedSubscriber.enableVirtualTime();
+		Mono<String> mono = Mono.never()
+		                        .timeout(Duration.ofDays(2))
+		                        .map(l -> "foo");
+
+		ScriptedSubscriber.create()
+		                  .advanceTimeTo(Instant.now().plus(Duration.ofDays(2)))
+		                  .expectError(TimeoutException.class)
+		                  .verify(mono);
 
 		ScriptedSubscriber.disableVirtualTime();
 	}


### PR DESCRIPTION
Add TestScheduler (WIP on periodic tasks support)
Add global hooks including `TestScheduler.enable(boolean: all)` and `ScriptedSubscriber.enable(all)`
Add scripted TestScheduler#advanceTimeXxx via `ScriptedSubscriber.ValueBuilder`.