### PR TITLE
fix #20 add ScriptedSubscriber#then(Runnable)

### DIFF
--- a/reactor-test/src/main/java/reactor/test/subscriber/DefaultScriptedSubscriberBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/subscriber/DefaultScriptedSubscriberBuilder.java
@@ -303,15 +303,22 @@ final class DefaultScriptedSubscriberBuilder<T>
 	@Override
 	public ScriptedSubscriber.ValueBuilder<T> doRequest(long n) {
 		checkForNegative(n);
-		this.script.add(new SubscriptionEvent<T>(subscription -> subscription.request(n),
+		this.script.add(new SubscriptionEvent<>(subscription -> subscription.request(n),
 				false));
 		return this;
 	}
 
 	@Override
 	public ScriptedSubscriber<T> doCancel() {
-		this.script.add(new SubscriptionEvent<T>(Subscription::cancel, true));
+		this.script.add(new SubscriptionEvent<>(Subscription::cancel, true));
 		return build();
+	}
+
+	@Override
+	public ScriptedSubscriber.ValueBuilder<T> then(Runnable task) {
+		Objects.requireNonNull(task, "task");
+		this.script.add(new TaskEvent<>(task));
+		return this;
 	}
 
 	final ScriptedSubscriber<T> build() {

--- a/reactor-test/src/main/java/reactor/test/subscriber/ScriptedSubscriber.java
+++ b/reactor-test/src/main/java/reactor/test/subscriber/ScriptedSubscriber.java
@@ -297,7 +297,7 @@ public interface ScriptedSubscriber<T> extends Subscriber<T> {
 		ValueBuilder<T> consumeValueWith(Consumer<T> consumer);
 
 		/**
-		 * Run an arbitrary task sequenced with after previous expectations or tasks.
+		 * Run an arbitrary task scheduled after previous expectations or tasks.
 		 * @param task the task to run
 		 * @return this builder
 		 */

--- a/reactor-test/src/main/java/reactor/test/subscriber/ScriptedSubscriber.java
+++ b/reactor-test/src/main/java/reactor/test/subscriber/ScriptedSubscriber.java
@@ -295,5 +295,12 @@ public interface ScriptedSubscriber<T> extends Subscriber<T> {
 		 * @return this builder
 		 */
 		ValueBuilder<T> consumeValueWith(Consumer<T> consumer);
+
+		/**
+		 * Run an arbitrary task sequenced with after previous expectations or tasks.
+		 * @param task the task to run
+		 * @return this builder
+		 */
+		ValueBuilder<T> then(Runnable task);
 	}
 }

--- a/reactor-test/src/test/java/reactor/test/subscriber/ScriptedSubscriberIntegrationTests.java
+++ b/reactor-test/src/test/java/reactor/test/subscriber/ScriptedSubscriberIntegrationTests.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeoutException;
 
 import org.junit.After;
 import org.junit.Test;
+import reactor.core.publisher.DirectProcessor;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -356,6 +357,22 @@ public class ScriptedSubscriberIntegrationTests {
 		                  .advanceTimeBy(Duration.ofSeconds(3))
 		                  .expectValue("t2")
 		                  .doCancel()
+		                  .verify(flux);
+
+	}
+
+	@Test
+	public void verifyThenOnCompleteInterval() {
+		DirectProcessor<Void> p = DirectProcessor.create();
+
+		Flux<String> flux = Flux.range(0, 3)
+		                        .map(d -> "t" + d)
+								.takeUntilOther(p);
+
+		ScriptedSubscriber.create(2)
+		                  .expectValues("t0", "t1")
+		                  .then(p::onComplete)
+		                  .expectComplete()
 		                  .verify(flux);
 
 	}


### PR DESCRIPTION
Demonstrated in here : https://github.com/reactor/reactor-addons/pull/27/files#diff-d5549340c0b8e8379fcfd6de48271d0eR365

This is a requirement for scripted steps that take interact with the tested Publisher.

I'd also like to align doRequest and doCancel under thenRequest and thenCancel.
WDYT @poutsma @sdeleuze @bclozel @nebhale