### PR TITLE
Suffix for predicate-based expects is now Match

### DIFF
--- a/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
@@ -234,7 +234,7 @@ final class DefaultStepVerifierBuilder<T>
 	}
 
 	@Override
-	public DefaultStepVerifier<T> expectErrorWith(Predicate<Throwable> predicate) {
+	public DefaultStepVerifier<T> expectErrorMatch(Predicate<Throwable> predicate) {
 		Objects.requireNonNull(predicate, "predicate");
 		SignalEvent<T> event = new SignalEvent<>(signal -> {
 			if (!signal.isOnError()) {
@@ -315,7 +315,7 @@ final class DefaultStepVerifierBuilder<T>
 	}
 
 	@Override
-	public DefaultStepVerifierBuilder<T> expectNextWith(
+	public DefaultStepVerifierBuilder<T> expectNextMatch(
 			Predicate<? super T> predicate) {
 		Objects.requireNonNull(predicate, "predicate");
 		SignalEvent<T> event = new SignalEvent<>(signal -> {
@@ -335,7 +335,7 @@ final class DefaultStepVerifierBuilder<T>
 	}
 
 	@Override
-	public DefaultStepVerifierBuilder<T> expectRecordedWith(
+	public DefaultStepVerifierBuilder<T> expectRecordedMatch(
 			Predicate<? super Collection<T>> predicate) {
 		Objects.requireNonNull(predicate, "predicate");
 		this.script.add(new CollectEvent<>(predicate));
@@ -354,7 +354,7 @@ final class DefaultStepVerifierBuilder<T>
 	}
 
 	@Override
-	public DefaultStepVerifierBuilder<T> expectSubscriptionWith(
+	public DefaultStepVerifierBuilder<T> expectSubscriptionMatch(
 			Predicate<? super Subscription> predicate) {
 		Objects.requireNonNull(predicate, "predicate");
 		this.script.set(0, new SignalEvent<>(signal -> {

--- a/reactor-test/src/main/java/reactor/test/StepVerifier.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifier.java
@@ -35,7 +35,7 @@ import reactor.test.scheduler.VirtualTimeScheduler;
  * <ul> <li>Create a {@code
  * StepVerifier} builder using {@link #create} or {@link #with}</li>
  * <li>Set individual up value expectations using
- * {@link Step#expectNext}, {@link Step#expectNextWith(Predicate)},
+ * {@link Step#expectNext}, {@link Step#expectNextMatch(Predicate)},
  * {@link Step#expectNextCount(long)} or
  * {@link Step#expectNextSequence(Iterable)}
  * .</li>  <li>Set up
@@ -45,7 +45,7 @@ import reactor.test.scheduler.VirtualTimeScheduler;
  * StepVerifier} using {@link LastStep#expectComplete},
  * {@link LastStep#expectError}, {@link
  * LastStep#expectError(Class) expectError(Class)}, {@link
- * LastStep#expectErrorWith(Predicate) expectErrorWith(Predicate)}, or {@link
+ * LastStep#expectErrorMatch(Predicate) expectErrorMatch(Predicate)}, or {@link
  * LastStep#thenCancel}. </li> <li>Subscribe the built {@code
  * StepVerifier} to a {@code Publisher}.</li> <li>Verify the expectations using
  * either {@link #verify()} or {@link #verify(Duration)}.</li> <li>If any expectations
@@ -255,7 +255,7 @@ public interface StepVerifier {
 		 *
 		 * @see Subscriber#onError(Throwable)
 		 */
-		StepVerifier expectErrorWith(Predicate<Throwable> predicate);
+		StepVerifier expectErrorMatch(Predicate<Throwable> predicate);
 
 		/**
 		 * Expect the completion signal.
@@ -351,7 +351,7 @@ public interface StepVerifier {
 		 *
 		 * @see Subscriber#onNext(Object)
 		 */
-		Step<T> expectNextWith(Predicate<? super T> predicate);
+		Step<T> expectNextMatch(Predicate<? super T> predicate);
 
 		/**
 		 * Expect that no event has been observed by the verifier. A duration is
@@ -377,13 +377,13 @@ public interface StepVerifier {
 		 *
 		 * @see Subscriber#onNext(Object)
 		 */
-		Step<T> expectRecordedWith(Predicate<? super Collection<T>> predicate);
+		Step<T> expectRecordedMatch(Predicate<? super Collection<T>> predicate);
 
 		/**
 		 * Start a recording session storing {@link Subscriber#onNext(Object)} values in
 		 * the
 		 * supplied {@link Collection}. Further steps
-		 * {@link #expectRecordedWith(Predicate)} and
+		 * {@link #expectRecordedMatch(Predicate)} and
 		 * {@link #consumeRecordedWith(Consumer)} can consume the session.
 		 * <p>If an
 		 * existing recording session hasn't not been declaratively consumed, this step
@@ -549,7 +549,7 @@ public interface StepVerifier {
 		 *
 		 * @see Subscriber#onSubscribe(Subscription)
 		 */
-		Step<T> expectSubscriptionWith(Predicate<? super Subscription> predicate);
+		Step<T> expectSubscriptionMatch(Predicate<? super Subscription> predicate);
 	}
 
 }

--- a/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
@@ -16,13 +16,11 @@
 package reactor.test;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 
-import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
 import reactor.core.Fuseable;
@@ -99,23 +97,23 @@ public class StepVerifierTests {
 	}
 
 	@Test
-	public void expectNextWith() {
+	public void expectNextMatch() {
 		Flux<String> flux = Flux.just("foo", "bar");
 
 		StepVerifier.create(flux)
-		            .expectNextWith("foo"::equals)
-		            .expectNextWith("bar"::equals)
+		            .expectNextMatch("foo"::equals)
+		            .expectNextMatch("bar"::equals)
 		            .expectComplete()
 		            .verify();
 	}
 
 	@Test(expected = AssertionError.class)
-	public void expectInvalidNextWith() {
+	public void expectInvalidNextMatch() {
 		Flux<String> flux = Flux.just("foo", "bar");
 
 		StepVerifier.create(flux)
-		            .expectNextWith("foo"::equals)
-		            .expectNextWith("baz"::equals)
+		            .expectNextMatch("foo"::equals)
+		            .expectNextMatch("baz"::equals)
 		            .expectComplete()
 		            .verify();
 	}
@@ -301,24 +299,24 @@ public class StepVerifierTests {
 	}
 
 	@Test
-	public void errorWith() {
+	public void errorMatch() {
 		Flux<String> flux = Flux.just("foo")
 		                        .concatWith(Mono.error(new IllegalArgumentException()));
 
 		StepVerifier.create(flux)
 		            .expectNext("foo")
-		            .expectErrorWith(t -> t instanceof IllegalArgumentException)
+		            .expectErrorMatch(t -> t instanceof IllegalArgumentException)
 		            .verify();
 	}
 
 	@Test(expected = AssertionError.class)
-	public void errorWithInvalid() {
+	public void errorMatchInvalid() {
 		Flux<String> flux = Flux.just("foo")
 		                        .concatWith(Mono.error(new IllegalArgumentException()));
 
 		StepVerifier.create(flux)
 		            .expectNext("foo")
-		            .expectErrorWith(t -> t instanceof IllegalStateException)
+		            .expectErrorMatch(t -> t instanceof IllegalStateException)
 		            .verify();
 	}
 
@@ -450,7 +448,7 @@ public class StepVerifierTests {
 		Mono<String> flux = Mono.just("foo");
 
 		StepVerifier.create(flux)
-		            .expectSubscriptionWith(s -> s instanceof Fuseable.QueueSubscription)
+		            .expectSubscriptionMatch(s -> s instanceof Fuseable.QueueSubscription)
 		            .expectNext("foo")
 		            .expectComplete()
 		            .verify();
@@ -499,25 +497,25 @@ public class StepVerifierTests {
 	}
 
 	@Test
-	public void verifyRecordWith() {
+	public void verifyRecordMatch() {
 		Flux<String> flux = Flux.just("foo", "bar", "foobar");
 
 		StepVerifier.create(flux)
 		            .recordWith(ArrayList::new)
 		            .expectNextCount(3)
-		            .expectRecordedWith(c -> c.contains("foobar"))
+		            .expectRecordedMatch(c -> c.contains("foobar"))
 		            .expectComplete()
 		            .verify();
 	}
 
 	@Test(expected = AssertionError.class)
-	public void verifyRecordWithError() {
+	public void verifyRecordMatchError() {
 		Flux<String> flux = Flux.just("foo", "bar", "foobar");
 
 		StepVerifier.create(flux)
 		            .recordWith(ArrayList::new)
 		            .expectNextCount(3)
-		            .expectRecordedWith(c -> c.contains("foofoo"))
+		            .expectRecordedMatch(c -> c.contains("foofoo"))
 		            .expectComplete()
 		            .verify();
 	}
@@ -533,12 +531,12 @@ public class StepVerifierTests {
 	}
 
 	@Test(expected = AssertionError.class)
-	public void verifyRecordWithError2() {
+	public void verifyRecordMatchError2() {
 		Flux<String> flux = Flux.just("foo", "bar", "foobar");
 
 		StepVerifier.create(flux)
 		            .expectNext("foo", "bar", "foobar")
-		            .expectRecordedWith(c -> c.size() == 3)
+		            .expectRecordedMatch(c -> c.size() == 3)
 		            .expectComplete()
 		            .verify();
 	}
@@ -562,7 +560,7 @@ public class StepVerifierTests {
 		Mono<String> flux = Mono.just("foo");
 
 		StepVerifier.create(flux)
-		            .expectSubscriptionWith(s -> false)
+		            .expectSubscriptionMatch(s -> false)
 		            .expectNext("foo")
 		            .expectComplete()
 		            .verify();


### PR DESCRIPTION
cc @smaldini @sdeleuze @nebhale

This commit renames all `expectXxxWith` methods that take a predicate
to use the `Match` suffix instead, which reads better in the context
of a predicate.