### PR TITLE
fix #37 Verify that produced amount doesn't overflow request

### DIFF
--- a/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
@@ -417,8 +417,7 @@ final class DefaultStepVerifierBuilder<T>
 	@Override
 	public DefaultStepVerifierBuilder<T> thenRequest(long n) {
 		checkStrictlyPositive(n);
-		this.script.add(new SubscriptionEvent<>(subscription -> subscription.request(n),
-				"thenRequest"));
+		this.script.add(new RequestEvent<T>(n, "thenRequest"));
 		return this;
 	}
 
@@ -577,6 +576,7 @@ final class DefaultStepVerifierBuilder<T>
 		int                           establishedFusionMode;
 		Fuseable.QueueSubscription<T> qs;
 		long                          produced;
+		volatile long                 requested;
 		Iterator<? extends T>         currentNextAs;
 		Collection<T>                 currentCollector;
 
@@ -618,6 +618,7 @@ final class DefaultStepVerifierBuilder<T>
 			this.produced = 0L;
 			this.completeLatch = new CountDownLatch(1);
 			this.subscription = new AtomicReference<>();
+			this.requested = initialRequest;
 		}
 
 		static <R> Queue<Event<R>> conflateScript(List<Event<R>> script, Logger logger) {
@@ -738,7 +739,10 @@ final class DefaultStepVerifierBuilder<T>
 				if (currentCollector != null) {
 					currentCollector.add(t);
 				}
-				onExpectation(Signal.next(t));
+				Signal<T> signal = Signal.next(t);
+				if (!checkRequestOverflow(signal)) {
+					onExpectation(signal);
+				}
 			}
 		}
 
@@ -864,6 +868,20 @@ final class DefaultStepVerifierBuilder<T>
 			}
 			else {
 				return Optional.empty();
+			}
+		}
+
+		/** Returns true if the requested amount was overflown by the given signal */
+		final boolean checkRequestOverflow(Signal<T> s) {
+			if (!s.isOnNext()
+					|| requested < 0 || requested == Long.MAX_VALUE //was Long.MAX from beginning or switched to unbounded
+					|| requested >= produced) {
+				return false;
+			}
+			else {
+				setFailure(null, s, "expected production of at most %s; produced: %s; request overflown by signal: %s",
+						requested, produced, s);
+				return true;
 			}
 		}
 
@@ -1089,6 +1107,15 @@ final class DefaultStepVerifierBuilder<T>
 			for (; ; ) {
 				if (this.script.peek() instanceof SubscriptionEvent) {
 					subscriptionEvent = (SubscriptionEvent<T>) this.script.poll();
+					if (subscriptionEvent instanceof RequestEvent) {
+						RequestEvent<T> requestEvent = (RequestEvent<T>) subscriptionEvent;
+						if (requestEvent.isBounded()) {
+							requested = Operators.addCap(requested, requestEvent.getRequestAmount());
+						}
+						else {
+							requested = Long.MAX_VALUE;
+						}
+					}
 					if (subscriptionEvent.isTerminal()) {
 						doCancel();
 						return true;
@@ -1255,7 +1282,7 @@ final class DefaultStepVerifierBuilder<T>
 		}
 	}
 
-	static final class SubscriptionEvent<T> extends AbstractEagerEvent<T> {
+	static class SubscriptionEvent<T> extends AbstractEagerEvent<T> {
 
 		final Consumer<Subscription> consumer;
 		
@@ -1276,6 +1303,24 @@ final class DefaultStepVerifierBuilder<T>
 
 		boolean isTerminal() {
 			return consumer == null;
+		}
+	}
+
+	static final class RequestEvent<T> extends SubscriptionEvent<T> {
+
+		final long requestAmount;
+
+		RequestEvent(long n, String desc) {
+			super(s -> s.request(n), desc);
+			this.requestAmount = n;
+		}
+
+		public long getRequestAmount() {
+			return requestAmount;
+		}
+
+		public boolean isBounded() {
+			return requestAmount >= 0 && requestAmount < Long.MAX_VALUE;
 		}
 	}
 

--- a/reactor-test/src/test/java/reactor/test/utils/RequestIgnoringProcessor.java
+++ b/reactor-test/src/test/java/reactor/test/utils/RequestIgnoringProcessor.java
@@ -1,0 +1,311 @@
+package reactor.test.utils;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import org.reactivestreams.Processor;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.MultiProducer;
+import reactor.core.Producer;
+import reactor.core.Receiver;
+import reactor.core.Trackable;
+import reactor.core.publisher.FluxProcessor;
+import reactor.core.publisher.Operators;
+
+/**
+ * A {@link Processor} derived from {@link reactor.core.publisher.DirectProcessor} except
+ * it allows {@link #onNext(Object)} calls even when the requested counter is &lt;= 0.
+ *
+ * @author Simon Baslé
+ */
+public final class RequestIgnoringProcessor<T>
+		extends FluxProcessor<T, T>
+		implements Receiver, MultiProducer {
+
+
+	/**
+	 * Create a new {@link RequestIgnoringProcessor}
+	 * @param <E> Type of processed signals
+	 * @return a fresh processor
+	 */
+	public static <E> RequestIgnoringProcessor<E> create() {
+		return new RequestIgnoringProcessor<>();
+	}
+
+	@SuppressWarnings("rawtypes")
+	private static final RequestIgnoringSubscription[] EMPTY = new RequestIgnoringSubscription[0];
+
+	@SuppressWarnings("rawtypes")
+	private static final RequestIgnoringSubscription[] TERMINATED = new RequestIgnoringSubscription[0];
+
+	@SuppressWarnings("unchecked")
+	private volatile     RequestIgnoringSubscription<T>[] subscribers = EMPTY;
+	@SuppressWarnings("rawtypes")
+	private static final AtomicReferenceFieldUpdater<RequestIgnoringProcessor, RequestIgnoringSubscription[]>
+	                                                      SUBSCRIBERS =
+			AtomicReferenceFieldUpdater.newUpdater(RequestIgnoringProcessor.class,
+					RequestIgnoringSubscription[].class,
+					"subscribers");
+
+	Throwable error;
+
+	RequestIgnoringProcessor() {
+	}
+
+	@Override
+	public long getPrefetch() {
+		return Long.MAX_VALUE;
+	}
+
+	@Override
+	public void onSubscribe(Subscription s) {
+		Objects.requireNonNull(s, "s");
+		if (subscribers != TERMINATED) {
+			s.request(Long.MAX_VALUE);
+		} else {
+			s.cancel();
+		}
+	}
+
+	@Override
+	public void onNext(T t) {
+		Objects.requireNonNull(t, "t");
+
+		for (RequestIgnoringSubscription<T> s : subscribers) {
+			s.onNext(t);
+		}
+	}
+
+	@Override
+	public void onError(Throwable t) {
+		Objects.requireNonNull(t, "t");
+
+		error = t;
+		for (RequestIgnoringSubscription<?> s : SUBSCRIBERS.getAndSet(this, TERMINATED)) {
+			s.onError(t);
+		}
+	}
+
+	@Override
+	public void onComplete() {
+		for (RequestIgnoringSubscription<?> s : SUBSCRIBERS.getAndSet(this, TERMINATED)) {
+			s.onComplete();
+		}
+	}
+
+	@Override
+	public void subscribe(Subscriber<? super T> s) {
+		Objects.requireNonNull(s, "s");
+
+		RequestIgnoringSubscription<T>
+				p = new RequestIgnoringSubscription<>(s, this);
+		s.onSubscribe(p);
+
+		if (add(p)) {
+			if (p.cancelled) {
+				remove(p);
+			}
+		} else {
+			Throwable e = error;
+			if (e != null) {
+				s.onError(e);
+			} else {
+				s.onComplete();
+			}
+		}
+	}
+
+	@Override
+	public boolean isStarted() {
+		return true;
+	}
+
+	@Override
+	public boolean isTerminated() {
+		return TERMINATED == subscribers;
+	}
+
+	@Override
+	public Iterator<?> downstreams() {
+		return Arrays.asList(subscribers).iterator();
+	}
+
+	@Override
+	public long downstreamCount() {
+		return subscribers.length;
+	}
+
+	boolean add(RequestIgnoringSubscription<T> s) {
+		RequestIgnoringSubscription<T>[] a = subscribers;
+		if (a == TERMINATED) {
+			return false;
+		}
+
+		synchronized (this) {
+			a = subscribers;
+			if (a == TERMINATED) {
+				return false;
+			}
+			int len = a.length;
+
+			@SuppressWarnings("unchecked") RequestIgnoringSubscription<T>[] b = new RequestIgnoringSubscription[len + 1];
+			System.arraycopy(a, 0, b, 0, len);
+			b[len] = s;
+
+			subscribers = b;
+
+			return true;
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	void remove(RequestIgnoringSubscription<T> s) {
+		RequestIgnoringSubscription<T>[] a = subscribers;
+		if (a == TERMINATED || a == EMPTY) {
+			return;
+		}
+
+		synchronized (this) {
+			a = subscribers;
+			if (a == TERMINATED || a == EMPTY) {
+				return;
+			}
+			int len = a.length;
+
+			int j = -1;
+
+			for (int i = 0; i < len; i++) {
+				if (a[i] == s) {
+					j = i;
+					break;
+				}
+			}
+			if (j < 0) {
+				return;
+			}
+			if (len == 1) {
+				subscribers = EMPTY;
+				return;
+			}
+
+			RequestIgnoringSubscription<T>[] b = new RequestIgnoringSubscription[len - 1];
+			System.arraycopy(a, 0, b, 0, j);
+			System.arraycopy(a, j + 1, b, j, len - j - 1);
+
+			subscribers = b;
+		}
+	}
+
+	@Override
+	public boolean hasDownstreams() {
+		RequestIgnoringSubscription<T>[] s = subscribers;
+		return s != EMPTY && s != TERMINATED;
+	}
+
+	public boolean hasCompleted() {
+		return subscribers == TERMINATED && error == null;
+	}
+
+	public boolean hasError() {
+		return subscribers == TERMINATED && error != null;
+	}
+
+	@Override
+	public Throwable getError() {
+		if (subscribers == TERMINATED) {
+			return error;
+		}
+		return null;
+	}
+
+	static final class RequestIgnoringSubscription<T> implements Subscription,
+	                                                             Receiver, Producer,
+	                                                             Trackable {
+
+		final Subscriber<? super T> actual;
+
+		final RequestIgnoringProcessor<T> parent;
+
+		volatile boolean cancelled;
+
+		volatile long requested;
+		@SuppressWarnings("rawtypes")
+		static final AtomicLongFieldUpdater<RequestIgnoringSubscription>
+				REQUESTED =
+				AtomicLongFieldUpdater.newUpdater(RequestIgnoringSubscription.class, "requested");
+
+		public RequestIgnoringSubscription(Subscriber<? super T> actual, RequestIgnoringProcessor<T> parent) {
+			this.actual = actual;
+			this.parent = parent;
+		}
+
+		@Override
+		public void request(long n) {
+			if (Operators.validate(n)) {
+				Operators.getAndAddCap(REQUESTED, this, n);
+			}
+		}
+
+		@Override
+		public void cancel() {
+			if (!cancelled) {
+				cancelled = true;
+				parent.remove(this);
+			}
+		}
+
+		@Override
+		public boolean isCancelled() {
+			return cancelled;
+		}
+
+		@Override
+		public Subscriber<? super T> downstream() {
+			return actual;
+		}
+
+		@Override
+		public long requestedFromDownstream() {
+			return 0;
+		}
+
+		@Override
+		public Processor<T, T> upstream() {
+			return parent;
+		}
+
+		void onNext(T value) {
+			actual.onNext(value);
+			if (requested != Long.MAX_VALUE) {
+				REQUESTED.decrementAndGet(this);
+			}
+		}
+
+		void onError(Throwable e) {
+			actual.onError(e);
+		}
+
+		void onComplete() {
+			actual.onComplete();
+		}
+
+		@Override
+		public boolean isStarted() {
+			return parent.isStarted();
+		}
+
+		@Override
+		public boolean isTerminated() {
+			return parent.isTerminated();
+		}
+	}
+
+	@Override
+	public Object upstream() {
+		return null;
+	}
+}


### PR DESCRIPTION
Note: as discussed with @smaldini, the next step is probably to introduce an `AssertPublisher` (that would replace the temporary, test-scoped `RequestIgnoringProcessor`). See #46 