### PR TITLE
fix #43 Convenience expect-and-verify methods

### DIFF
--- a/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
@@ -416,6 +416,31 @@ final class DefaultStepVerifierBuilder<T>
 	}
 
 	@Override
+	public Duration verifyError() {
+		return expectError().verify();
+	}
+
+	@Override
+	public Duration verifyError(Class<? extends Throwable> clazz) {
+		return expectError(clazz).verify();
+	}
+
+	@Override
+	public Duration verifyErrorMessage(String errorMessage) {
+		return expectErrorMessage(errorMessage).verify();
+	}
+
+	@Override
+	public Duration verifyErrorMatches(Predicate<Throwable> predicate) {
+		return expectErrorMatches(predicate).verify();
+	}
+
+	@Override
+	public Duration verifyComplete() {
+		return expectComplete().verify();
+	}
+
+	@Override
 	public DefaultStepVerifierBuilder<T> thenRequest(long n) {
 		checkStrictlyPositive(n);
 		this.script.add(new RequestEvent<T>(n, "thenRequest"));

--- a/reactor-test/src/main/java/reactor/test/StepVerifier.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifier.java
@@ -272,6 +272,96 @@ public interface StepVerifier {
 		 * @see Subscription#cancel()
 		 */
 		StepVerifier thenCancel();
+
+		/**
+		 * Trigger the {@link #verify() verification}, expecting an unspecified error
+		 * as terminal event.
+		 * <p>
+		 * This is a convenience method that calls {@link #verify()} in addition to the
+		 * expectation. Explicitly use the expect method and verification method
+		 * separately if you need something more specific (like activating logging or
+		 * putting a timeout).
+		 *
+		 * @return the {@link Duration} of the verification
+		 *
+		 * @see #expectError()
+		 * @see #verify()
+		 * @see Subscriber#onError(Throwable)
+		 */
+		Duration verifyError();
+
+		/**
+		 * Trigger the {@link #verify() verification}, expecting an error of the specified
+		 * type as terminal event.
+		 * <p>
+		 * This is a convenience method that calls {@link #verify()} in addition to the
+		 * expectation. Explicitly use the expect method and verification method
+		 * separately if you need something more specific (like activating logging or
+		 * putting a timeout).
+		 *
+		 * @param clazz the expected error type
+		 * @return the {@link Duration} of the verification
+		 *
+		 * @see #expectError(Class)
+		 * @see #verify()
+		 * @see Subscriber#onError(Throwable)
+		 */
+		Duration verifyError(Class<? extends Throwable> clazz);
+
+		/**
+		 * Trigger the {@link #verify() verification}, expecting an error with the
+		 * specified messagee as terminal event.
+		 * <p>
+		 * This is a convenience method that calls {@link #verify()} in addition to the
+		 * expectation. Explicitly use the expect method and verification method
+		 * separately if you need something more specific (like activating logging or
+		 * putting a timeout).
+		 *
+		 * @param errorMessage the expected error message
+		 * @return the {@link Duration} of the verification
+		 *
+		 * @see #expectErrorMessage(String)
+		 * @see #verify()
+		 * @see Subscriber#onError(Throwable)
+		 */
+		Duration verifyErrorMessage(String errorMessage);
+
+		/**
+		 * Trigger the {@link #verify() verification}, expecting an error that matches
+		 * the given predicate as terminal event.
+		 * <p>
+		 * This is a convenience method that calls {@link #verify()} in addition to the
+		 * expectation. Explicitly use the expect method and verification method
+		 * separately if you need something more specific (like activating logging or
+		 * putting a timeout).
+		 *
+		 * @param predicate the predicate to test on the next received error
+		 * @return the {@link Duration} of the verification
+		 *
+		 * @see #expectErrorMatches(Predicate)
+		 * @see #verify()
+		 * @see Subscriber#onError(Throwable)
+		 */
+		Duration verifyErrorMatches(Predicate<Throwable> predicate);
+
+		/**
+		 * Trigger the {@link #verify() verification}, expecting a completion signal
+		 * as terminal event.
+		 * <p>
+		 * This is a convenience method that calls {@link #verify()} in addition to the
+		 * expectation. Explicitly use the expect method and verification method
+		 * separately if you need something more specific (like activating logging or
+		 * putting a timeout).
+		 *
+		 * @return the {@link Duration} of the verification
+		 *
+		 * @see #expectComplete()
+		 * @see #verify()
+		 * @see Subscriber#onComplete()
+		 *
+		 */
+		Duration verifyComplete();
+
 	}
 
 	/**

--- a/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
@@ -1227,4 +1227,84 @@ public class StepVerifierTests {
 	                .verify();
 	}
 
+	@Test
+	public void verifyErrorTriggersVerification() {
+		try {
+			StepVerifier.create(Flux.empty())
+			            .verifyError();
+			fail("expected verifyError to fail");
+		}
+		catch (AssertionError e) {
+			assertEquals("expectation \"expectError()\" failed (expected: onError(); actual: onComplete())",
+					e.getMessage());
+		}
+
+		StepVerifier.create(Flux.error(new IllegalArgumentException()))
+		            .verifyError();
+	}
+
+	@Test
+	public void verifyErrorClassTriggersVerification() {
+		try {
+			StepVerifier.create(Flux.empty())
+			            .verifyError(IllegalArgumentException.class);
+			fail("expected verifyError to fail");
+		}
+		catch (AssertionError e) {
+			assertEquals("expectation \"expectError(Class)\" failed (expected: onError(IllegalArgumentException); actual: onComplete())",
+					e.getMessage());
+		}
+
+		StepVerifier.create(Flux.error(new IllegalArgumentException()))
+		            .verifyError(IllegalArgumentException.class);
+	}
+
+	@Test
+	public void verifyErrorMessageTriggersVerification() {
+		try {
+			StepVerifier.create(Flux.empty())
+			            .verifyErrorMessage("boom");
+			fail("expected verifyError to fail");
+		}
+		catch (AssertionError e) {
+			assertEquals("expectation \"expectErrorMessage\" failed (expected: onError(\"boom\"); actual: onComplete())",
+					e.getMessage());
+		}
+
+		StepVerifier.create(Flux.error(new IllegalArgumentException("boom")))
+		            .verifyErrorMessage("boom");
+	}
+
+	@Test
+	public void verifyErrorPredicateTriggersVerification() {
+		try {
+			StepVerifier.create(Flux.empty())
+			            .verifyErrorMatches(e -> e instanceof IllegalArgumentException);
+			fail("expected verifyError to fail");
+		}
+		catch (AssertionError e) {
+			assertEquals("expectation \"expectErrorMatches\" failed (expected: onError(); actual: onComplete())",
+					e.getMessage());
+		}
+
+		StepVerifier.create(Flux.error(new IllegalArgumentException("boom")))
+		            .verifyErrorMatches(e -> e instanceof IllegalArgumentException);
+	}
+
+	@Test
+	public void verifyCompleteTriggersVerification() {
+		try {
+			StepVerifier.create(Flux.error(new IllegalArgumentException()))
+		                .verifyComplete();
+			fail("expected verifyComplete to fail");
+		}
+		catch (AssertionError e) {
+			assertEquals("expectation \"expectComplete\" failed (expected: onComplete(); actual: onError(java.lang.IllegalArgumentException))", e.getMessage());
+		}
+
+			StepVerifier.create(Flux.just(1, 2))
+			            .expectNext(1, 2)
+		                .verifyComplete();
+	}
+
 }

--- a/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
@@ -1228,39 +1228,47 @@ public class StepVerifierTests {
 	}
 
 	@Test
-	public void verifyErrorTriggersVerification() {
+	public void verifyErrorTriggersVerificationFail() {
 		try {
 			StepVerifier.create(Flux.empty())
 			            .verifyError();
 			fail("expected verifyError to fail");
 		}
 		catch (AssertionError e) {
-			assertEquals("expectation \"expectError()\" failed (expected: onError(); actual: onComplete())",
+			assertEquals(
+					"expectation \"expectError()\" failed (expected: onError(); actual: onComplete())",
 					e.getMessage());
 		}
+	}
 
+	@Test
+	public void verifyErrorTriggersVerificationSuccess() {
 		StepVerifier.create(Flux.error(new IllegalArgumentException()))
 		            .verifyError();
 	}
 
 	@Test
-	public void verifyErrorClassTriggersVerification() {
+	public void verifyErrorClassTriggersVerificationFail() {
 		try {
 			StepVerifier.create(Flux.empty())
 			            .verifyError(IllegalArgumentException.class);
 			fail("expected verifyError to fail");
 		}
 		catch (AssertionError e) {
-			assertEquals("expectation \"expectError(Class)\" failed (expected: onError(IllegalArgumentException); actual: onComplete())",
+			assertEquals(
+					"expectation \"expectError(Class)\" failed (expected: onError(IllegalArgumentException); actual: onComplete())",
 					e.getMessage());
 		}
+	}
 
+	@Test
+	public void verifyErrorClassTriggersVerificationSuccess() {
 		StepVerifier.create(Flux.error(new IllegalArgumentException()))
 		            .verifyError(IllegalArgumentException.class);
 	}
 
 	@Test
-	public void verifyErrorMessageTriggersVerification() {
+	public void verifyErrorMessageTriggersVerificationFail() {
 		try {
 			StepVerifier.create(Flux.empty())
 			            .verifyErrorMessage("boom");
@@ -1270,13 +1278,16 @@ public class StepVerifierTests {
 			assertEquals("expectation \"expectErrorMessage\" failed (expected: onError(\"boom\"); actual: onComplete())",
 					e.getMessage());
 		}
+	}
 
+	@Test
+	public void verifyErrorMessageTriggersVerificationSuccess() {
 		StepVerifier.create(Flux.error(new IllegalArgumentException("boom")))
 		            .verifyErrorMessage("boom");
 	}
 
 	@Test
-	public void verifyErrorPredicateTriggersVerification() {
+	public void verifyErrorPredicateTriggersVerificationFail() {
 		try {
 			StepVerifier.create(Flux.empty())
 			            .verifyErrorMatches(e -> e instanceof IllegalArgumentException);
@@ -1286,13 +1297,16 @@ public class StepVerifierTests {
 			assertEquals("expectation \"expectErrorMatches\" failed (expected: onError(); actual: onComplete())",
 					e.getMessage());
 		}
+	}
 
+	@Test
+	public void verifyErrorPredicateTriggersVerificationSuccess() {
 		StepVerifier.create(Flux.error(new IllegalArgumentException("boom")))
 		            .verifyErrorMatches(e -> e instanceof IllegalArgumentException);
 	}
 
 	@Test
-	public void verifyCompleteTriggersVerification() {
+	public void verifyCompleteTriggersVerificationFail() {
 		try {
 			StepVerifier.create(Flux.error(new IllegalArgumentException()))
 		                .verifyComplete();
@@ -1301,7 +1315,10 @@ public class StepVerifierTests {
 		catch (AssertionError e) {
 			assertEquals("expectation \"expectComplete\" failed (expected: onComplete(); actual: onError(java.lang.IllegalArgumentException))", e.getMessage());
 		}
+	}
 
+	@Test
+	public void verifyCompleteTriggersVerificationSuccess() {
 			StepVerifier.create(Flux.just(1, 2))
 			            .expectNext(1, 2)
 		                .verifyComplete();


### PR DESCRIPTION
Add methods that combine `expectError`/`expectComplete` with a call to the simple `.verify()`.
For more advanced usage where one desires to have logging or timeout, the usual `expect` method followed by `log()`/`verify()`/`verify(Duration)` should be used instead.

@smaldini can I get a review? :mag_right:

cc @sdeleuze @msoub @aalmiray