### PR TITLE
fix #38 Consistent argument order for n in create methods

### DIFF
--- a/reactor-test/src/main/java/reactor/test/StepVerifier.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifier.java
@@ -116,7 +116,17 @@ public interface StepVerifier {
 	 * @return a builder for setting up value expectations
 	 */
 	static <T> FirstStep<T> withVirtualTime(Supplier<? extends Publisher<? extends T>> scenarioSupplier) {
-		return withVirtualTime(Long.MAX_VALUE, scenarioSupplier);
+		return withVirtualTime(scenarioSupplier, Long.MAX_VALUE);
+	}
+
+	/**
+	 * @deprecated to be removed in 3.1.0 for parameter ordering harmonization. Please
+	 * use {@link #withVirtualTime(Supplier, long)} instead.
+	 */
+	@Deprecated
+	static <T> FirstStep<T> withVirtualTime(long n,
+			Supplier<? extends Publisher<? extends T>> scenarioSupplier) {
+		return withVirtualTime(scenarioSupplier, () -> VirtualTimeScheduler.enable(false), n);
 	}
 
 	/**
@@ -125,15 +135,31 @@ public interface StepVerifier {
 	 * {@link Step#thenAwait}. Each {@link #verify()} will fully (re)play the
 	 * scenario. The verification will request a specified amount of values.
 	 *
-	 * @param n the amount of items to request (must be &gt;= 0)
 	 * @param scenarioSupplier a mandatory supplier of the {@link Publisher} to test
+	 * @param n the amount of items to request (must be &gt;= 0)
 	 * @param <T> the type of the subscriber
 	 *
 	 * @return a builder for setting up value expectations
 	 */
+	static <T> FirstStep<T> withVirtualTime(Supplier<? extends Publisher<? extends T>> scenarioSupplier,
+			long n) {
+		return withVirtualTime(scenarioSupplier, () -> VirtualTimeScheduler.enable(false), n);
+	}
+
+	/**
+	 * @deprecated to be removed in 3.1.0 for parameter ordering harmonization. Please
+	 * use {@link #withVirtualTime(Supplier, Supplier, long)} instead.
+	 */
 	static <T> FirstStep<T> withVirtualTime(long n,
-			Supplier<? extends Publisher<? extends T>> scenarioSupplier) {
-		return withVirtualTime(n, scenarioSupplier, () -> VirtualTimeScheduler.enable(false));
+			Supplier<? extends Publisher<? extends T>> scenarioSupplier,
+			Supplier<? extends VirtualTimeScheduler> vtsLookup) {
+		DefaultStepVerifierBuilder.checkPositive(n);
+		Objects.requireNonNull(scenarioSupplier, "scenarioSupplier");
+		Objects.requireNonNull(vtsLookup, "vtsLookup");
+
+		return DefaultStepVerifierBuilder.newVerifier(n,
+				scenarioSupplier,
+				vtsLookup);
 	}
 
 	/**
@@ -143,17 +169,18 @@ public interface StepVerifier {
 	 * {@link Step#thenAwait}. Each {@link #verify()} will fully (re)play the
 	 * scenario. The verification will request a specified amount of values.
 	 *
-	 * @param n the amount of items to request (must be &gt;= 0)
 	 * @param scenarioSupplier a mandatory supplier of the {@link Publisher} to test
 	 * @param vtsLookup a mandatory {@link VirtualTimeScheduler} lookup to use in {@code
 	 * thenAwait}
+	 * @param n the amount of items to request (must be &gt;= 0)
 	 * @param <T> the type of the subscriber
 	 *
 	 * @return a builder for setting up value expectations
 	 */
-	static <T> FirstStep<T> withVirtualTime(long n,
+	static <T> FirstStep<T> withVirtualTime(
 			Supplier<? extends Publisher<? extends T>> scenarioSupplier,
-			Supplier<? extends VirtualTimeScheduler> vtsLookup) {
+			Supplier<? extends VirtualTimeScheduler> vtsLookup,
+			long n) {
 		DefaultStepVerifierBuilder.checkPositive(n);
 		Objects.requireNonNull(scenarioSupplier, "scenarioSupplier");
 		Objects.requireNonNull(vtsLookup, "vtsLookup");

--- a/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
@@ -827,12 +827,12 @@ public class StepVerifierTests {
 
 	@Test(expected = NullPointerException.class)
 	public void verifyVirtualTimeNoLookupFails() {
-		StepVerifier.withVirtualTime(1, Flux::empty, null);
+		StepVerifier.withVirtualTime(Flux::empty, null, 1);
 	}
 
 	@Test(expected = NullPointerException.class)
 	public void verifyVirtualTimeNoScenarioFails() {
-		StepVerifier.withVirtualTime(1, null);
+		StepVerifier.withVirtualTime(null, 1);
 	}
 
 	@Test(timeout = 3000)
@@ -849,9 +849,9 @@ public class StepVerifierTests {
 
 	@Test
 	public void verifyVirtualTimeOnErrorInterval() {
-		StepVerifier.withVirtualTime(0,
-				() -> Flux.interval(Duration.ofSeconds(3))
-				          .map(d -> "t" + d))
+		StepVerifier.withVirtualTime(() -> Flux.interval(Duration.ofSeconds(3))
+		                                       .map(d -> "t" + d),
+				0)
 		            .thenRequest(1)
 		            .thenAwait(Duration.ofSeconds(3))
 		            .expectNext("t0")
@@ -867,10 +867,9 @@ public class StepVerifierTests {
 	@Test
 	public void verifyVirtualTimeOnErrorAsync() {
 		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
-		StepVerifier.withVirtualTime(0,
-				() -> Flux.just(123)
-				          .subscribeOn(vts),
-				() -> vts)
+		StepVerifier.withVirtualTime(() -> Flux.just(123)
+		                                       .subscribeOn(vts),
+				() -> vts, 0)
 		            .thenRequest(1)
 		            .thenAwait()
 		            .expectNext(123)
@@ -882,10 +881,10 @@ public class StepVerifierTests {
 	@Test(timeout = 1000)
 	public void verifyCreatedSchedulerUsesVirtualTime() {
 		//a timeout will occur if virtual time isn't used
-		StepVerifier.withVirtualTime(0,
-				() -> Flux.interval(Duration.ofSeconds(3))
-				          .map(d -> "t" + d),
-				VirtualTimeScheduler::create)
+		StepVerifier.withVirtualTime(() -> Flux.interval(Duration.ofSeconds(3))
+		                                       .map(d -> "t" + d),
+				VirtualTimeScheduler::create,
+				0)
 		            .thenRequest(1)
 		            .thenAwait(Duration.ofSeconds(1))
 		            .thenAwait(Duration.ofSeconds(2))
@@ -897,10 +896,10 @@ public class StepVerifierTests {
 	@Test(timeout = 1000)
 	public void verifyCreatedForAllSchedulerUsesVirtualTime() {
 		//a timeout will occur if virtual time isn't used
-		StepVerifier.withVirtualTime(0,
-				() -> Flux.interval(Duration.ofSeconds(3))
-				          .map(d -> "t" + d),
-				VirtualTimeScheduler::createForAll)
+		StepVerifier.withVirtualTime(() -> Flux.interval(Duration.ofSeconds(3))
+		                                       .map(d -> "t" + d),
+				VirtualTimeScheduler::createForAll,
+				0)
 		            .thenRequest(1)
 		            .thenAwait(Duration.ofSeconds(1))
 		            .thenAwait(Duration.ofSeconds(2))
@@ -922,7 +921,7 @@ public class StepVerifierTests {
 
 	@Test(timeout = 500)
 	public void noSignalVirtualTime() {
-		StepVerifier.withVirtualTime(1, Mono::never)
+		StepVerifier.withVirtualTime(Mono::never, 1)
 		            .expectSubscription()
 		            .expectNoEvent(Duration.ofSeconds(100))
 		            .thenCancel()
@@ -931,10 +930,10 @@ public class StepVerifierTests {
 
 	@Test
 	public void longDelayAndNoTermination() {
-		StepVerifier.withVirtualTime(Long.MAX_VALUE,
-				() -> Flux.just("foo", "bar")
-				          .delay(Duration.ofSeconds(5))
-				          .concatWith(Mono.never()))
+		StepVerifier.withVirtualTime(() -> Flux.just("foo", "bar")
+		                                       .delay(Duration.ofSeconds(5))
+		                                       .concatWith(Mono.never()),
+				Long.MAX_VALUE)
 		            .expectSubscription()
 		            .expectNoEvent(Duration.ofSeconds(5))
 		            .expectNext("foo")


### PR DESCRIPTION
@smaldini I went with what @sdeleuze was proposing. You were talking
about the benefit of the other order in languages like Kotlin though?