### PR TITLE
fix #86 Add TestPublisher multiple terminations violation

### DIFF
--- a/reactor-test/src/main/java/reactor/test/publisher/DefaultTestPublisher.java
+++ b/reactor-test/src/main/java/reactor/test/publisher/DefaultTestPublisher.java
@@ -305,7 +305,13 @@ class DefaultTestPublisher<T> extends TestPublisher<T> {
 		Objects.requireNonNull(t, "t");
 
 		error = t;
-		for (TestPublisherSubscription<?> s : SUBSCRIBERS.getAndSet(this, TERMINATED)) {
+		TestPublisherSubscription<?>[] subs;
+		if (violations.contains(Violation.CLEANUP_ON_TERMINATE)) {
+			subs = subscribers;
+		} else {
+			subs = SUBSCRIBERS.getAndSet(this, TERMINATED);
+		}
+		for (TestPublisherSubscription<?> s : subs) {
 			s.onError(t);
 		}
 		return this;
@@ -313,7 +319,13 @@ class DefaultTestPublisher<T> extends TestPublisher<T> {
 
 	@Override
 	public DefaultTestPublisher<T> complete() {
-		for (TestPublisherSubscription<?> s : SUBSCRIBERS.getAndSet(this, TERMINATED)) {
+		TestPublisherSubscription<?>[] subs;
+		if (violations.contains(Violation.CLEANUP_ON_TERMINATE)) {
+			subs = subscribers;
+		} else {
+			subs = SUBSCRIBERS.getAndSet(this, TERMINATED);
+		}
+		for (TestPublisherSubscription<?> s : subs) {
 			s.onComplete();
 		}
 		return this;

--- a/reactor-test/src/main/java/reactor/test/publisher/TestPublisher.java
+++ b/reactor-test/src/main/java/reactor/test/publisher/TestPublisher.java
@@ -199,6 +199,12 @@ public abstract class TestPublisher<T> implements Publisher<T> {
 		 * Allow {@link TestPublisher#next(Object, Object[]) next}  calls to be made
 		 * with a {@code null} value without triggering a {@link NullPointerException}
 		 */
-		ALLOW_NULL
+		ALLOW_NULL,
+		/**
+		 * Allow termination signals to be sent several times in a row. This includes
+		 * {@link TestPublisher#complete()}, {@link TestPublisher#error(Throwable)} and
+		 * {@link TestPublisher#emit(Object[])}.
+		 */
+		CLEANUP_ON_TERMINATE
 	}
 }


### PR DESCRIPTION
This commit adds a Violation that can be used with TestPublisher to let
it complete/error/terminate several times in a row. The normal behavior
is still for the publisher to silently ignore such attempts at multiple
terminations.