### PR TITLE
Have StepVerifier explicitly reset VTS factory

### DIFF
--- a/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
@@ -576,7 +576,9 @@ final class DefaultStepVerifierBuilder<T>
 				VirtualTimeScheduler vts = null;
 				if (parent.vtsLookup != null) {
 					vts = parent.vtsLookup.get();
-					VirtualTimeScheduler.enable(vts);
+					//this works even for the default case where StepVerifier has created
+					// a vts through enable(false), because the CURRENT will already be that vts
+					VirtualTimeScheduler.set(vts);
 				}
 				try {
 					Publisher<? extends T> publisher = parent.sourceSupplier.get();
@@ -598,6 +600,9 @@ final class DefaultStepVerifierBuilder<T>
 				finally {
 					if (vts != null) {
 						vts.shutdown();
+						//explicitly reset the factory, rather than rely on vts shutdown doing so
+						// because it could have been eagerly shut down in a test.
+						VirtualTimeScheduler.reset();
 					}
 				}
 			} else {

--- a/reactor-test/src/main/java/reactor/test/StepVerifier.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifier.java
@@ -126,7 +126,7 @@ public interface StepVerifier {
 	@Deprecated
 	static <T> FirstStep<T> withVirtualTime(long n,
 			Supplier<? extends Publisher<? extends T>> scenarioSupplier) {
-		return withVirtualTime(scenarioSupplier, () -> VirtualTimeScheduler.enable(false), n);
+		return withVirtualTime(scenarioSupplier, () -> VirtualTimeScheduler.getOrSet(false), n);
 	}
 
 	/**
@@ -143,7 +143,7 @@ public interface StepVerifier {
 	 */
 	static <T> FirstStep<T> withVirtualTime(Supplier<? extends Publisher<? extends T>> scenarioSupplier,
 			long n) {
-		return withVirtualTime(scenarioSupplier, () -> VirtualTimeScheduler.enable(false), n);
+		return withVirtualTime(scenarioSupplier, () -> VirtualTimeScheduler.getOrSet(false), n);
 	}
 
 	/**

--- a/reactor-test/src/main/java/reactor/test/StepVerifier.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifier.java
@@ -150,6 +150,7 @@ public interface StepVerifier {
 	 * @deprecated to be removed in 3.1.0 for parameter ordering harmonization. Please
 	 * use {@link #withVirtualTime(Supplier, Supplier, long)} instead.
 	 */
+	@Deprecated
 	static <T> FirstStep<T> withVirtualTime(long n,
 			Supplier<? extends Publisher<? extends T>> scenarioSupplier,
 			Supplier<? extends VirtualTimeScheduler> vtsLookup) {

--- a/reactor-test/src/main/java/reactor/test/publisher/TestPublisher.java
+++ b/reactor-test/src/main/java/reactor/test/publisher/TestPublisher.java
@@ -157,7 +157,7 @@ public abstract class TestPublisher<T> implements Publisher<T> {
 	 * @param first the first item to emit
 	 * @param rest the optional remaining items to emit
 	 * @return this {@link TestPublisher} for chaining.
-	 * @see #next(T) next
+	 * @see #next(Object) next
 	 */
 	@SafeVarargs
 	public final TestPublisher<T> next(T first, T... rest) {
@@ -174,7 +174,7 @@ public abstract class TestPublisher<T> implements Publisher<T> {
 	 *
 	 * @param values the values to emit to subscribers
 	 * @return this {@link TestPublisher} for chaining.
-	 * @see #next(T) next
+	 * @see #next(Object) next
 	 * @see #complete() complete
 	 */
 	@SafeVarargs

--- a/reactor-test/src/test/java/reactor/test/DefaultStepVerifierBuilderTests.java
+++ b/reactor-test/src/test/java/reactor/test/DefaultStepVerifierBuilderTests.java
@@ -64,7 +64,7 @@ public class DefaultStepVerifierBuilderTests {
 	public void manuallyManagedVirtualTime() {
 		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
 		try {
-			VirtualTimeScheduler.enable(vts);
+			VirtualTimeScheduler.getOrSet(vts);
 
 			Flux<String> flux = Flux.just("foo").delay(Duration.ofSeconds(4));
 

--- a/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
@@ -1642,4 +1642,19 @@ public class StepVerifierTests {
 					.verify();
 	}
 
+	@Test
+	public void virtualTimeSchedulerUseExactlySupplied() {
+		VirtualTimeScheduler vts1 = VirtualTimeScheduler.create();
+		VirtualTimeScheduler vts2 = VirtualTimeScheduler.create();
+		VirtualTimeScheduler.getOrSet(vts1);
+
+		StepVerifier.withVirtualTime(Mono::empty, () -> vts2, Long.MAX_VALUE)
+		            .then(() -> assertThat(VirtualTimeScheduler.get()).isSameAs(vts2))
+		            .verifyComplete();
+
+		assertThat(vts1.isDisposed()).isFalse();
+		assertThat(vts2.isDisposed()).isTrue();
+		assertThat(VirtualTimeScheduler.isFactoryEnabled()).isFalse();
+	}
+
 }


### PR DESCRIPTION
@smaldini see the TODO in `DefaultStepVerifierBuilder`, I'm not entirely sure the behavior of `VirtualTimeScheduler.shutdown` should be changed to remove the "reset" part, since VTS could be used in standalone mode.