### PR TITLE
add assertThatScenario() to StepVerifier, assert drop hooks, duration

### DIFF
--- a/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
@@ -576,7 +576,7 @@ final class DefaultStepVerifierBuilder<T>
 		}
 
 		@Override
-		public StepVerifierAssertions assertThatScenario() {
+		public StepVerifierAssertions verifyThenAssertThat() {
 			//plug in the correct hooks
 			Queue<Object> droppedElements = new ConcurrentLinkedQueue<>();
 			AtomicReference<Throwable> droppedError = new AtomicReference<>();
@@ -964,7 +964,7 @@ final class DefaultStepVerifierBuilder<T>
 		}
 
 		@Override
-		public StepVerifierAssertions assertThatScenario() {
+		public StepVerifierAssertions verifyThenAssertThat() {
 			//plug in the correct hooks
 			Queue<Object> droppedElements = new ConcurrentLinkedQueue<>();
 			AtomicReference<Throwable> droppedError = new AtomicReference<>();
@@ -1590,10 +1590,10 @@ final class DefaultStepVerifierBuilder<T>
 		}
 
 		@Override
-		public StepVerifier.StepVerifierAssertions hasDroppedErrorMatching(Function<Throwable, Boolean> matcher) {
+		public StepVerifier.StepVerifierAssertions hasDroppedErrorMatching(Predicate<Throwable> matcher) {
 			satisfies(() -> matcher != null, () -> "Require non-null matcher");
 			hasDroppedError();
-			return satisfies(() -> matcher.apply(droppedError.get()),
+			return satisfies(() -> matcher.test(droppedError.get()),
 					() -> String.format("Expected dropped error matching the given predicate, did not match: <%s>.", droppedError.get()));
 		}
 

--- a/reactor-test/src/main/java/reactor/test/StepVerifier.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifier.java
@@ -799,34 +799,53 @@ public interface StepVerifier {
 		StepVerifierAssertions hasDroppedExactly(Object... values);
 
 		/**
-		 * Assert that the tested publisher has dropped an error to the
+		 * Assert that the tested publisher has dropped at least one error to the
 		 * {@link Hooks#onErrorDropped(Consumer)} hook.
 		 */
-		StepVerifierAssertions hasDroppedError();
+		StepVerifierAssertions hasDroppedErrors();
 
 		/**
-		 * Assert that the tested publisher has dropped an error of the given type to the
+		 * Assert that the tested publisher has dropped exactly n errors to the
 		 * {@link Hooks#onErrorDropped(Consumer)} hook.
+		 */
+		StepVerifierAssertions hasDroppedErrors(int n);
+
+		/**
+		 * Assert that the tested publisher has dropped exactly one error of the given type
+		 * to the {@link Hooks#onErrorDropped(Consumer)} hook.
 		 */
 		StepVerifierAssertions hasDroppedErrorOfType(Class<? extends Throwable> clazz);
 
 		/**
-		 * Assert that the tested publisher has dropped an error matching the given
+		 * Assert that the tested publisher has dropped exactly one error matching the given
 		 * predicate to the {@link Hooks#onErrorDropped(Consumer)} hook.
 		 */
 		StepVerifierAssertions hasDroppedErrorMatching(Predicate<Throwable> matcher);
 
 		/**
-		 * Assert that the tested publisher has dropped an error with the exact provided
+		 * Assert that the tested publisher has dropped exactly one error with the exact provided
 		 * message to the {@link Hooks#onErrorDropped(Consumer)} hook.
 		 */
 		StepVerifierAssertions hasDroppedErrorWithMessage(String message);
 
 		/**
-		 * Assert that the tested publisher has dropped an error with a message containing
+		 * Assert that the tested publisher has dropped exactly one error with a message containing
 		 * the provided string to the {@link Hooks#onErrorDropped(Consumer)} hook.
 		 */
 		StepVerifierAssertions hasDroppedErrorWithMessageContaining(String messagePart);
+
+		/**
+		 * Assert that the tested publisher has dropped one or more errors to the
+		 * {@link Hooks#onErrorDropped(Consumer)} hook, and assert them as a collection.
+		 */
+		StepVerifierAssertions hasDroppedErrorsSatisfying(Consumer<Collection<Throwable>> errorsConsumer);
+
+		/**
+		 * Assert that the tested publisher has dropped one or more errors to the
+		 * {@link Hooks#onErrorDropped(Consumer)} hook, and check that the collection of
+		 * errors matches a predicate.
+		 */
+		StepVerifierAssertions hasDroppedErrorsMatching(Predicate<Collection<Throwable>> errorsConsumer);
 
 		/**
 		 * Assert that the whole verification took strictly less than the provided

--- a/reactor-test/src/main/java/reactor/test/StepVerifier.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifier.java
@@ -19,6 +19,7 @@ package reactor.test;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Objects;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -29,6 +30,7 @@ import org.reactivestreams.Subscription;
 import reactor.core.Fuseable;
 import reactor.core.publisher.Hooks;
 import reactor.test.scheduler.VirtualTimeScheduler;
+import reactor.util.function.Tuple2;
 
 /**
  * A {@link StepVerifier} is a verifiable, blocking script usually produced by
@@ -846,6 +848,55 @@ public interface StepVerifier {
 		 * errors matches a predicate.
 		 */
 		StepVerifierAssertions hasDroppedErrorsMatching(Predicate<Collection<Throwable>> errorsConsumer);
+
+		/**
+		 * Assert that the tested publisher has triggered the {@link Hooks#onOperatorError(BiFunction) onOperatorError} hook
+		 * at least once.
+		 */
+		StepVerifierAssertions hasOperatorErrors();
+
+		/**
+		 * Assert that the tested publisher has triggered the {@link Hooks#onOperatorError(BiFunction) onOperatorError} hook
+		 * exactly n times.
+		 */
+		StepVerifierAssertions hasOperatorErrors(int n);
+
+		/**
+		 * Assert that the tested publisher has triggered the {@link Hooks#onOperatorError(BiFunction) onOperatorError} hook
+		 * exactly once and the error is of the given type.
+		 */
+		StepVerifierAssertions hasOperatorErrorOfType(Class<? extends Throwable> clazz);
+
+		/**
+		 * Assert that the tested publisher has triggered the {@link Hooks#onOperatorError(BiFunction) onOperatorError} hook
+		 * exactly once and the error matches the given predicate.
+		 */
+		StepVerifierAssertions hasOperatorErrorMatching(Predicate<Throwable> matcher);
+
+		/**
+		 * Assert that the tested publisher has triggered the {@link Hooks#onOperatorError(BiFunction) onOperatorError} hook
+		 * exactly once and the error has the exact provided message.
+		 */
+		StepVerifierAssertions hasOperatorErrorWithMessage(String message);
+
+		/**
+		 * Assert that the tested publisher has triggered the {@link Hooks#onOperatorError(BiFunction) onOperatorError} hook
+		 * exactly once, with the error message containing the provided string.
+		 */
+		StepVerifierAssertions hasOperatorErrorWithMessageContaining(String messagePart);
+
+		/**
+		 * Assert that the tested publisher has triggered the {@link Hooks#onOperatorError(BiFunction) onOperatorError} hook
+		 * once or more, and assert the errors and optionally associated data as a collection.
+		 */
+		StepVerifierAssertions hasOperatorErrorsSatisfying(Consumer<Collection<Tuple2<Throwable, ?>>> errorsConsumer);
+
+		/**
+		 * Assert that the tested publisher has triggered the {@link Hooks#onOperatorError(BiFunction) onOperatorError} hook
+		 * once or more, and check that the collection of errors and their optionally
+		 * associated data matches a predicate.
+		 */
+		StepVerifierAssertions hasOperatorErrorsMatching(Predicate<Collection<Tuple2<Throwable, ?>>> errorsConsumer);
 
 		/**
 		 * Assert that the whole verification took strictly less than the provided

--- a/reactor-test/src/main/java/reactor/test/StepVerifier.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifier.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
@@ -265,6 +266,8 @@ public interface StepVerifier {
 	 *                        times out
 	 */
 	Duration verify(Duration duration) throws AssertionError;
+
+	StepVerifierAssertions assertThatScenario();
 
 	/**
 	 * Define a builder for terminal states.
@@ -757,6 +760,29 @@ public interface StepVerifier {
 		 * @see Subscriber#onSubscribe(Subscription)
 		 */
 		Step<T> expectSubscriptionMatches(Predicate<? super Subscription> predicate);
+	}
+
+	interface StepVerifierAssertions {
+
+		StepVerifierAssertions hasDroppedElements();
+
+		StepVerifierAssertions hasDropped(Object... values);
+
+		StepVerifierAssertions hasDroppedExactly(Object... values);
+
+		StepVerifierAssertions hasDroppedError();
+
+		StepVerifierAssertions hasDroppedErrorOfType(Class<? extends Throwable> clazz);
+
+		StepVerifierAssertions hasDroppedErrorMatching(Function<Throwable, Boolean> matcher);
+
+		StepVerifierAssertions hasDroppedErrorWithMessage(String message);
+
+		StepVerifierAssertions hasDroppedErrorWithMessageContaining(String messagePart);
+
+		StepVerifierAssertions tookLessThan(Duration d);
+
+		StepVerifierAssertions tookMoreThan(Duration d);
 	}
 
 }

--- a/reactor-test/src/test/java/reactor/test/StepVerifierAssertionsTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierAssertionsTests.java
@@ -23,7 +23,7 @@ public class StepVerifierAssertionsTests {
 		}).take(3))
 		            .expectNext("foo")
 		            .expectComplete()
-		            .assertThatScenario()
+		            .verifyThenAssertThat()
 		            .hasDroppedElements()
 		            .hasDropped("baz")
 		            .hasDroppedExactly("baz", "bar");
@@ -34,7 +34,7 @@ public class StepVerifierAssertionsTests {
 		try {
 			StepVerifier.create(Mono.empty())
 			            .expectComplete()
-			            .assertThatScenario()
+			            .verifyThenAssertThat()
 			            .hasDroppedElements();
 			fail("expected an AssertionError");
 		}
@@ -55,7 +55,7 @@ public class StepVerifierAssertionsTests {
 			}).take(3))
 			            .expectNext("foo")
 			            .expectComplete()
-			            .assertThatScenario()
+			            .verifyThenAssertThat()
 			            .hasDropped("foo");
 			fail("expected an AssertionError");
 		}
@@ -76,7 +76,7 @@ public class StepVerifierAssertionsTests {
 			}).take(3))
 			            .expectNext("foo")
 			            .expectComplete()
-			            .assertThatScenario()
+			            .verifyThenAssertThat()
 			            .hasDroppedExactly("baz");
 			fail("expected an AssertionError");
 		}
@@ -95,7 +95,7 @@ public class StepVerifierAssertionsTests {
 			s.onError(err2);
 		}).buffer(1))
 		            .expectError()
-		            .assertThatScenario()
+		            .verifyThenAssertThat()
 		            .hasDroppedError()
 		            .hasDroppedErrorOfType(IllegalStateException.class)
 		            .hasDroppedErrorWithMessageContaining("boom")
@@ -108,7 +108,7 @@ public class StepVerifierAssertionsTests {
 		try {
 			StepVerifier.create(Mono.empty())
 			            .expectComplete()
-			            .assertThatScenario()
+			            .verifyThenAssertThat()
 			            .hasDroppedError();
 			fail("expected an AssertionError");
 		}
@@ -128,7 +128,7 @@ public class StepVerifierAssertionsTests {
 				s.onError(err2);
 			}).buffer(1))
 			            .expectError()
-			            .assertThatScenario()
+			            .verifyThenAssertThat()
 			            .hasDroppedErrorOfType(IllegalArgumentException.class);
 			fail("expected an AssertionError");
 		}
@@ -148,7 +148,7 @@ public class StepVerifierAssertionsTests {
 				s.onError(err2);
 			}).buffer(1))
 			            .expectError()
-			            .assertThatScenario()
+			            .verifyThenAssertThat()
 			            .hasDroppedErrorWithMessageContaining("foo");
 			fail("expected an AssertionError");
 		}
@@ -168,7 +168,7 @@ public class StepVerifierAssertionsTests {
 				s.onError(err2);
 			}).buffer(1))
 			            .expectError()
-			            .assertThatScenario()
+			            .verifyThenAssertThat()
 			            .hasDroppedErrorWithMessage("boom1");
 			fail("expected an AssertionError");
 		}
@@ -188,7 +188,7 @@ public class StepVerifierAssertionsTests {
 				s.onError(err2);
 			}).buffer(1))
 			            .expectError()
-			            .assertThatScenario()
+			            .verifyThenAssertThat()
 			            .hasDroppedErrorMatching(t -> t instanceof IllegalStateException && "foo".equals(t.getMessage()));
 			fail("expected an AssertionError");
 		}
@@ -201,7 +201,7 @@ public class StepVerifierAssertionsTests {
 	public void assertDurationLessThanOk() {
 		StepVerifier.create(Mono.delay(Duration.ofMillis(500)).then())
 		            .expectComplete()
-		            .assertThatScenario()
+		            .verifyThenAssertThat()
 		            .tookLessThan(Duration.ofSeconds(1));
 	}
 
@@ -210,7 +210,7 @@ public class StepVerifierAssertionsTests {
 		try {
 			StepVerifier.create(Mono.delay(Duration.ofMillis(500)).then())
 		                .expectComplete()
-		                .assertThatScenario()
+		                .verifyThenAssertThat()
 		                .tookLessThan(Duration.ofMillis(200));
 
 			fail("expected an AssertionError");
@@ -234,7 +234,7 @@ public class StepVerifierAssertionsTests {
 	public void assertDurationMoreThanOk() {
 		StepVerifier.create(Mono.delay(Duration.ofMillis(500)).then())
 		            .expectComplete()
-		            .assertThatScenario()
+		            .verifyThenAssertThat()
 		            .tookMoreThan(Duration.ofMillis(100));
 	}
 
@@ -243,7 +243,7 @@ public class StepVerifierAssertionsTests {
 		try {
 			StepVerifier.create(Mono.delay(Duration.ofMillis(500)).then())
 		                .expectComplete()
-		                .assertThatScenario()
+		                .verifyThenAssertThat()
 		                .tookMoreThan(Duration.ofMillis(800));
 
 			fail("expected an AssertionError");

--- a/reactor-test/src/test/java/reactor/test/StepVerifierAssertionsTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierAssertionsTests.java
@@ -1,0 +1,259 @@
+package reactor.test;
+
+import java.time.Duration;
+
+import org.junit.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Operators;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+public class StepVerifierAssertionsTests {
+
+	@Test
+	public void assertDroppedElementsAllPass() {
+		StepVerifier.create(Flux.from(s -> {
+			s.onSubscribe(Operators.emptySubscription());
+			s.onNext("foo");
+			s.onComplete();
+			s.onNext("bar");
+			s.onNext("baz");
+		}).take(3))
+		            .expectNext("foo")
+		            .expectComplete()
+		            .assertThatScenario()
+		            .hasDroppedElements()
+		            .hasDropped("baz")
+		            .hasDroppedExactly("baz", "bar");
+	}
+
+	@Test
+	public void assertDroppedElementsFailureNoDrop() {
+		try {
+			StepVerifier.create(Mono.empty())
+			            .expectComplete()
+			            .assertThatScenario()
+			            .hasDroppedElements();
+			fail("expected an AssertionError");
+		}
+		catch (AssertionError ae) {
+			assertThat(ae).hasMessage("Expected dropped elements, none found.");
+		}
+	}
+
+	@Test
+	public void assertDroppedElementsFailureOneExtra() {
+		try {
+			StepVerifier.create(Flux.from(s -> {
+				s.onSubscribe(Operators.emptySubscription());
+				s.onNext("foo");
+				s.onComplete();
+				s.onNext("bar");
+				s.onNext("baz");
+			}).take(3))
+			            .expectNext("foo")
+			            .expectComplete()
+			            .assertThatScenario()
+			            .hasDropped("foo");
+			fail("expected an AssertionError");
+		}
+		catch (AssertionError ae) {
+			assertThat(ae).hasMessage("Expected dropped elements to contain <[foo]>, was <[bar, baz]>.");
+		}
+	}
+
+	@Test
+	public void assertDroppedElementsFailureOneMissing() {
+		try {
+			StepVerifier.create(Flux.from(s -> {
+				s.onSubscribe(Operators.emptySubscription());
+				s.onNext("foo");
+				s.onComplete();
+				s.onNext("bar");
+				s.onNext("baz");
+			}).take(3))
+			            .expectNext("foo")
+			            .expectComplete()
+			            .assertThatScenario()
+			            .hasDroppedExactly("baz");
+			fail("expected an AssertionError");
+		}
+		catch (AssertionError ae) {
+			assertThat(ae).hasMessage("Expected dropped elements to contain exactly <[baz]>, was <[bar, baz]>.");
+		}
+	}
+
+	@Test
+	public void assertDroppedErrorAllPass() {
+		Throwable err1 = new IllegalStateException("boom1");
+		Throwable err2 = new IllegalStateException("boom2");
+		StepVerifier.create(Flux.from(s -> {
+			s.onSubscribe(Operators.emptySubscription());
+			s.onError(err1);
+			s.onError(err2);
+		}).buffer(1))
+		            .expectError()
+		            .assertThatScenario()
+		            .hasDroppedError()
+		            .hasDroppedErrorOfType(IllegalStateException.class)
+		            .hasDroppedErrorWithMessageContaining("boom")
+		            .hasDroppedErrorWithMessage("boom2")
+		            .hasDroppedErrorMatching(t -> t instanceof IllegalStateException && "boom2".equals(t.getMessage()));
+	}
+
+	@Test
+	public void assertDroppedErrorFailureNoDrop() {
+		try {
+			StepVerifier.create(Mono.empty())
+			            .expectComplete()
+			            .assertThatScenario()
+			            .hasDroppedError();
+			fail("expected an AssertionError");
+		}
+		catch (AssertionError ae) {
+			assertThat(ae).hasMessage("Expected dropped error, none found.");
+		}
+	}
+
+	@Test
+	public void assertDroppedErrorFailureWrongType() {
+		try {
+			Throwable err1 = new IllegalStateException("boom1");
+			Throwable err2 = new IllegalStateException("boom2");
+			StepVerifier.create(Flux.from(s -> {
+				s.onSubscribe(Operators.emptySubscription());
+				s.onError(err1);
+				s.onError(err2);
+			}).buffer(1))
+			            .expectError()
+			            .assertThatScenario()
+			            .hasDroppedErrorOfType(IllegalArgumentException.class);
+			fail("expected an AssertionError");
+		}
+		catch (AssertionError ae) {
+			assertThat(ae).hasMessage("Expected dropped error to be of type java.lang.IllegalArgumentException, was java.lang.IllegalStateException.");
+		}
+	}
+
+	@Test
+	public void assertDroppedErrorFailureWrongContains() {
+		try {
+			Throwable err1 = new IllegalStateException("boom1");
+			Throwable err2 = new IllegalStateException("boom2");
+			StepVerifier.create(Flux.from(s -> {
+				s.onSubscribe(Operators.emptySubscription());
+				s.onError(err1);
+				s.onError(err2);
+			}).buffer(1))
+			            .expectError()
+			            .assertThatScenario()
+			            .hasDroppedErrorWithMessageContaining("foo");
+			fail("expected an AssertionError");
+		}
+		catch (AssertionError ae) {
+			assertThat(ae).hasMessage("Expected dropped error with message containing <\"foo\">, was <\"boom2\">.");
+		}
+	}
+
+	@Test
+	public void assertDroppedErrorFailureWrongMessage() {
+		try {
+			Throwable err1 = new IllegalStateException("boom1");
+			Throwable err2 = new IllegalStateException("boom2");
+			StepVerifier.create(Flux.from(s -> {
+				s.onSubscribe(Operators.emptySubscription());
+				s.onError(err1);
+				s.onError(err2);
+			}).buffer(1))
+			            .expectError()
+			            .assertThatScenario()
+			            .hasDroppedErrorWithMessage("boom1");
+			fail("expected an AssertionError");
+		}
+		catch (AssertionError ae) {
+			assertThat(ae).hasMessage("Expected dropped error with message <\"boom1\">, was <\"boom2\">.");
+		}
+	}
+
+	@Test
+	public void assertDroppedErrorFailureWrongMatch() {
+		try {
+			Throwable err1 = new IllegalStateException("boom1");
+			Throwable err2 = new IllegalStateException("boom2");
+			StepVerifier.create(Flux.from(s -> {
+				s.onSubscribe(Operators.emptySubscription());
+				s.onError(err1);
+				s.onError(err2);
+			}).buffer(1))
+			            .expectError()
+			            .assertThatScenario()
+			            .hasDroppedErrorMatching(t -> t instanceof IllegalStateException && "foo".equals(t.getMessage()));
+			fail("expected an AssertionError");
+		}
+		catch (AssertionError ae) {
+			assertThat(ae).hasMessage("Expected dropped error matching the given predicate, did not match: <java.lang.IllegalStateException: boom2>.");
+		}
+	}
+
+	@Test
+	public void assertDurationLessThanOk() {
+		StepVerifier.create(Mono.delay(Duration.ofMillis(500)).then())
+		            .expectComplete()
+		            .assertThatScenario()
+		            .tookLessThan(Duration.ofSeconds(1));
+	}
+
+	@Test
+	public void assertDurationLessThanFailure() {
+		try {
+			StepVerifier.create(Mono.delay(Duration.ofMillis(500)).then())
+		                .expectComplete()
+		                .assertThatScenario()
+		                .tookLessThan(Duration.ofMillis(200));
+
+			fail("expected an AssertionError");
+		}
+		catch (AssertionError ae) {
+			assertThat(ae)
+					//the actual duration can vary a bit
+					.hasMessageStartingWith("Expected scenario to be verified in less than 200ms, took 5")
+					.hasMessageEndingWith("ms.");
+		}
+	}
+
+	@Test
+	public void assertDurationConsidersEqualsASuccess() {
+		new DefaultStepVerifierBuilder.DefaultStepVerifierAssertions(null, null, Duration.ofSeconds(3))
+				.tookLessThan(Duration.ofMillis(3000L))
+				.tookMoreThan(Duration.ofSeconds(3));
+	}
+
+	@Test
+	public void assertDurationMoreThanOk() {
+		StepVerifier.create(Mono.delay(Duration.ofMillis(500)).then())
+		            .expectComplete()
+		            .assertThatScenario()
+		            .tookMoreThan(Duration.ofMillis(100));
+	}
+
+	@Test
+	public void assertDurationMoreThanFailure() {
+		try {
+			StepVerifier.create(Mono.delay(Duration.ofMillis(500)).then())
+		                .expectComplete()
+		                .assertThatScenario()
+		                .tookMoreThan(Duration.ofMillis(800));
+
+			fail("expected an AssertionError");
+		}
+		catch (AssertionError ae) {
+			assertThat(ae)
+					//the actual duration can vary a bit
+					.hasMessageStartingWith("Expected scenario to be verified in more than 800ms, took 5")
+					.hasMessageEndingWith("ms.");
+		}
+	}
+
+}


### PR DESCRIPTION
first pass: added a method used instead of `verify()`, that places hooks, calls `verify()` and reset hooks.
It then returns a `StepVerifierAssertions` that can be used to assert various states.
For now:
 - error dropped
 - elements dropped
 - duration of verify