### PR TITLE
fix #76 StepVerifierOptions to disable under-request check

### DIFF
--- a/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
@@ -76,12 +76,11 @@ final class DefaultStepVerifierBuilder<T>
 	}
 
 	static <T> StepVerifier.FirstStep<T> newVerifier(StepVerifierOptions options,
-			Supplier<? extends Publisher<? extends T>> scenarioSupplier,
-			Supplier<? extends VirtualTimeScheduler> vtsLookup) {
+			Supplier<? extends Publisher<? extends T>> scenarioSupplier) {
 		DefaultStepVerifierBuilder.checkPositive(options.getInitialRequest());
 		Objects.requireNonNull(scenarioSupplier, "scenarioSupplier");
 
-		return new DefaultStepVerifierBuilder<>(options, scenarioSupplier, vtsLookup);
+		return new DefaultStepVerifierBuilder<>(options, scenarioSupplier);
 	}
 
 	@SuppressWarnings("unchecked")
@@ -100,11 +99,10 @@ final class DefaultStepVerifierBuilder<T>
 	int  expectedFusionMode  = -1;
 
 	DefaultStepVerifierBuilder(StepVerifierOptions options,
-			Supplier<? extends Publisher<? extends T>> sourceSupplier,
-			Supplier<? extends VirtualTimeScheduler> vtsLookup) {
+			Supplier<? extends Publisher<? extends T>> sourceSupplier) {
 		this.initialRequest = options.getInitialRequest();
 		this.options = options;
-		this.vtsLookup = vtsLookup;
+		this.vtsLookup = options.getVirtualTimeSchedulerSupplier();
 		this.sourceSupplier = sourceSupplier;
 		this.script = new ArrayList<>();
 		this.script.add(defaultFirstStep());

--- a/reactor-test/src/main/java/reactor/test/StepVerifier.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifier.java
@@ -119,7 +119,7 @@ public interface StepVerifier {
 	 *                        times out
 	 */
 	static <T> FirstStep<T> create(Publisher<? extends T> publisher, StepVerifierOptions options) {
-		return DefaultStepVerifierBuilder.newVerifier(options, () -> publisher, null);
+		return DefaultStepVerifierBuilder.newVerifier(options, () -> publisher);
 	}
 
 	/**
@@ -176,10 +176,10 @@ public interface StepVerifier {
 		Objects.requireNonNull(scenarioSupplier, "scenarioSupplier");
 		Objects.requireNonNull(vtsLookup, "vtsLookup");
 
-		StepVerifierOptions options = new StepVerifierOptions().initialRequest(n);
+		StepVerifierOptions options = new StepVerifierOptions().initialRequest(n)
+				.virtualTimeSchedulerSupplier(vtsLookup);
 		return DefaultStepVerifierBuilder.newVerifier(options,
-				scenarioSupplier,
-				vtsLookup);
+				scenarioSupplier);
 	}
 
 	/**
@@ -201,7 +201,9 @@ public interface StepVerifier {
 			Supplier<? extends Publisher<? extends T>> scenarioSupplier,
 			Supplier<? extends VirtualTimeScheduler> vtsLookup,
 			long n) {
-		return withVirtualTime(scenarioSupplier, vtsLookup, new StepVerifierOptions().initialRequest(n));
+		return withVirtualTime(scenarioSupplier, new StepVerifierOptions()
+				.initialRequest(n)
+				.virtualTimeSchedulerSupplier(vtsLookup));
 	}
 
 	/**
@@ -212,24 +214,21 @@ public interface StepVerifier {
 	 * the provided {@link StepVerifierOptions options}.
 	 *
 	 * @param scenarioSupplier a mandatory supplier of the {@link Publisher} to test
-	 * @param vtsLookup a mandatory {@link VirtualTimeScheduler} lookup to use in {@code
-	 * thenAwait}
-	 * @param options the verification options
+	 * @param options the verification options, including a mandatory
+	 *      {@link VirtualTimeScheduler} lookup to use in {@code thenAwait}
 	 * @param <T> the type of the subscriber
 	 *
 	 * @return a builder for setting up value expectations
 	 */
 	static <T> FirstStep<T> withVirtualTime(
 			Supplier<? extends Publisher<? extends T>> scenarioSupplier,
-			Supplier<? extends VirtualTimeScheduler> vtsLookup,
 			StepVerifierOptions options) {
 		DefaultStepVerifierBuilder.checkPositive(options.getInitialRequest());
+		Objects.requireNonNull(options.getVirtualTimeSchedulerSupplier(), "vtsLookup");
 		Objects.requireNonNull(scenarioSupplier, "scenarioSupplier");
-		Objects.requireNonNull(vtsLookup, "vtsLookup");
 
 		return DefaultStepVerifierBuilder.newVerifier(options,
-				scenarioSupplier,
-				vtsLookup);
+				scenarioSupplier);
 	}
 
 	/**

--- a/reactor-test/src/main/java/reactor/test/StepVerifier.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifier.java
@@ -101,7 +101,7 @@ public interface StepVerifier {
 	 */
 	static <T> FirstStep<T> create(Publisher<? extends T> publisher,
 			long n) {
-		return create(publisher, new StepVerifierOptions().initialRequest(n));
+		return create(publisher, StepVerifierOptions.create().initialRequest(n));
 	}
 
 	/**
@@ -176,7 +176,8 @@ public interface StepVerifier {
 		Objects.requireNonNull(scenarioSupplier, "scenarioSupplier");
 		Objects.requireNonNull(vtsLookup, "vtsLookup");
 
-		StepVerifierOptions options = new StepVerifierOptions().initialRequest(n)
+		StepVerifierOptions options = StepVerifierOptions.create()
+				.initialRequest(n)
 				.virtualTimeSchedulerSupplier(vtsLookup);
 		return DefaultStepVerifierBuilder.newVerifier(options,
 				scenarioSupplier);
@@ -201,7 +202,7 @@ public interface StepVerifier {
 			Supplier<? extends Publisher<? extends T>> scenarioSupplier,
 			Supplier<? extends VirtualTimeScheduler> vtsLookup,
 			long n) {
-		return withVirtualTime(scenarioSupplier, new StepVerifierOptions()
+		return withVirtualTime(scenarioSupplier, StepVerifierOptions.create()
 				.initialRequest(n)
 				.virtualTimeSchedulerSupplier(vtsLookup));
 	}

--- a/reactor-test/src/main/java/reactor/test/StepVerifierOptions.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifierOptions.java
@@ -17,6 +17,16 @@ public class StepVerifierOptions {
 	private Supplier<? extends VirtualTimeScheduler> vtsLookup = null;
 
 	/**
+	 * Create a new default set of options for a {@link StepVerifier} that can be tuned
+	 * using the various available non-getter methods (which can be chained).
+	 */
+	public static StepVerifierOptions create() {
+		return new StepVerifierOptions();
+	}
+
+	private StepVerifierOptions() { } //disable constructor
+
+	/**
 	 * Activate or deactivate the {@link StepVerifier} check of request amount
 	 * being too low. Defauts to true.
 	 *

--- a/reactor-test/src/main/java/reactor/test/StepVerifierOptions.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifierOptions.java
@@ -1,8 +1,12 @@
 package reactor.test;
 
+import java.util.function.Supplier;
+
+import reactor.test.scheduler.VirtualTimeScheduler;
+
 /**
- * Options for a {@link StepVerifier}, including the initial request amount and
- * toggling of some checks.
+ * Options for a {@link StepVerifier}, including the initial request amount,
+ * {@link VirtualTimeScheduler} supplier and toggles for some checks.
  *
  * @author Simon Baslé
  */
@@ -10,6 +14,7 @@ public class StepVerifierOptions {
 
 	private boolean checkUnderRequesting = true;
 	private long initialRequest = Long.MAX_VALUE;
+	private Supplier<? extends VirtualTimeScheduler> vtsLookup = null;
 
 	/**
 	 * Activate or deactivate the {@link StepVerifier} check of request amount
@@ -51,4 +56,24 @@ public class StepVerifierOptions {
 		return this.initialRequest;
 	}
 
+	/**
+	 * Set a supplier for a {@link VirtualTimeScheduler}, which is mandatory for a
+	 * {@link StepVerifier} to work with virtual time. Defaults to null.
+	 *
+	 * @param vtsLookup the supplier of {@link VirtualTimeScheduler} to use.
+	 * @return this instance, to continue setting the options.
+	 */
+	public StepVerifierOptions virtualTimeSchedulerSupplier(Supplier<? extends VirtualTimeScheduler> vtsLookup) {
+		this.vtsLookup = vtsLookup;
+		return this;
+	}
+
+	/**
+	 * @return the supplier of {@link VirtualTimeScheduler} to be used by the
+	 * {@link StepVerifier} receiving these options.
+	 *
+	 */
+	public Supplier<? extends VirtualTimeScheduler> getVirtualTimeSchedulerSupplier() {
+		return vtsLookup;
+	}
 }

--- a/reactor-test/src/main/java/reactor/test/StepVerifierOptions.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifierOptions.java
@@ -1,0 +1,54 @@
+package reactor.test;
+
+/**
+ * Options for a {@link StepVerifier}, including the initial request amount and
+ * toggling of some checks.
+ *
+ * @author Simon Baslé
+ */
+public class StepVerifierOptions {
+
+	private boolean checkUnderRequesting = true;
+	private long initialRequest = Long.MAX_VALUE;
+
+	/**
+	 * Activate or deactivate the {@link StepVerifier} check of request amount
+	 * being too low. Defauts to true.
+	 *
+	 * @param enabled true if the check should be enabled.
+	 * @return this instance, to continue setting the options.
+	 */
+	public StepVerifierOptions checkUnderRequesting(boolean enabled) {
+		this.checkUnderRequesting = enabled;
+		return this;
+	}
+
+	/**
+	 * @return true if the {@link StepVerifier} receiving these options should activate
+	 * the check of request amount being too low.
+	 */
+	public boolean isCheckUnderRequesting() {
+		return this.checkUnderRequesting;
+	}
+
+	/**
+	 * Set the amount the {@link StepVerifier} should request initially. Defaults to
+	 * unbounded request ({@code Long.MAX_VALUE}).
+	 *
+	 * @param initialRequest the initial request amount.
+	 * @return this instance, to continue setting the options.
+	 */
+	public StepVerifierOptions initialRequest(long initialRequest) {
+		this.initialRequest = initialRequest;
+		return this;
+	}
+
+	/**
+	 * @return the initial request amount to be made by the {@link StepVerifier}
+	 * receiving these options.
+	 */
+	public long getInitialRequest() {
+		return this.initialRequest;
+	}
+
+}

--- a/reactor-test/src/test/java/reactor/test/DefaultStepVerifierBuilderTests.java
+++ b/reactor-test/src/test/java/reactor/test/DefaultStepVerifierBuilderTests.java
@@ -47,7 +47,7 @@ public class DefaultStepVerifierBuilderTests {
 		Flux<String> flux = Flux.just("foo", "bar");
 
 		DefaultVerifySubscriber<String> s =
-				new DefaultStepVerifierBuilder<String>(Long.MAX_VALUE,
+				new DefaultStepVerifierBuilder<String>(new StepVerifierOptions().initialRequest(Long.MAX_VALUE),
 						null,
 						null).expectNext("foo", "bar")
 				             .expectComplete()
@@ -69,7 +69,7 @@ public class DefaultStepVerifierBuilderTests {
 			Flux<String> flux = Flux.just("foo").delay(Duration.ofSeconds(4));
 
 			DefaultVerifySubscriber<String> s =
-					new DefaultStepVerifierBuilder<String>(Long.MAX_VALUE,
+					new DefaultStepVerifierBuilder<String>(new StepVerifierOptions().initialRequest(Long.MAX_VALUE),
 					null, //important to avoid triggering of vts capture-and-enable
 					() -> vts)
 					.thenAwait(Duration.ofSeconds(1))
@@ -93,7 +93,7 @@ public class DefaultStepVerifierBuilderTests {
 	public void suppliedVirtualTimeButNoSourceDoesntEnableScheduler() {
 		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
 
-		new DefaultStepVerifierBuilder<String>(Long.MAX_VALUE,
+		new DefaultStepVerifierBuilder<String>(new StepVerifierOptions().initialRequest(Long.MAX_VALUE),
 							null, //important to avoid triggering of vts capture-and-enable
 							() -> vts)
 							.expectNoEvent(Duration.ofSeconds(4))

--- a/reactor-test/src/test/java/reactor/test/DefaultStepVerifierBuilderTests.java
+++ b/reactor-test/src/test/java/reactor/test/DefaultStepVerifierBuilderTests.java
@@ -47,7 +47,7 @@ public class DefaultStepVerifierBuilderTests {
 		Flux<String> flux = Flux.just("foo", "bar");
 
 		DefaultVerifySubscriber<String> s =
-				new DefaultStepVerifierBuilder<String>(new StepVerifierOptions().initialRequest(Long.MAX_VALUE), null)
+				new DefaultStepVerifierBuilder<String>(StepVerifierOptions.create().initialRequest(Long.MAX_VALUE), null)
 						.expectNext("foo", "bar")
 						.expectComplete()
 				.toSubscriber();
@@ -68,7 +68,7 @@ public class DefaultStepVerifierBuilderTests {
 			Flux<String> flux = Flux.just("foo").delay(Duration.ofSeconds(4));
 
 			DefaultVerifySubscriber<String> s =
-					new DefaultStepVerifierBuilder<String>(new StepVerifierOptions()
+					new DefaultStepVerifierBuilder<String>(StepVerifierOptions.create()
 							.initialRequest(Long.MAX_VALUE)
 							.virtualTimeSchedulerSupplier(() -> vts),
 					null)//important to avoid triggering of vts capture-and-enable
@@ -93,7 +93,7 @@ public class DefaultStepVerifierBuilderTests {
 	public void suppliedVirtualTimeButNoSourceDoesntEnableScheduler() {
 		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
 
-		new DefaultStepVerifierBuilder<String>(new StepVerifierOptions()
+		new DefaultStepVerifierBuilder<String>(StepVerifierOptions.create()
 				.initialRequest(Long.MAX_VALUE)
 				.virtualTimeSchedulerSupplier(() -> vts),
 				null) //important to avoid triggering of vts capture-and-enable

--- a/reactor-test/src/test/java/reactor/test/DefaultStepVerifierBuilderTests.java
+++ b/reactor-test/src/test/java/reactor/test/DefaultStepVerifierBuilderTests.java
@@ -47,10 +47,9 @@ public class DefaultStepVerifierBuilderTests {
 		Flux<String> flux = Flux.just("foo", "bar");
 
 		DefaultVerifySubscriber<String> s =
-				new DefaultStepVerifierBuilder<String>(new StepVerifierOptions().initialRequest(Long.MAX_VALUE),
-						null,
-						null).expectNext("foo", "bar")
-				             .expectComplete()
+				new DefaultStepVerifierBuilder<String>(new StepVerifierOptions().initialRequest(Long.MAX_VALUE), null)
+						.expectNext("foo", "bar")
+						.expectComplete()
 				.toSubscriber();
 
 		flux.subscribe(s);
@@ -69,9 +68,10 @@ public class DefaultStepVerifierBuilderTests {
 			Flux<String> flux = Flux.just("foo").delay(Duration.ofSeconds(4));
 
 			DefaultVerifySubscriber<String> s =
-					new DefaultStepVerifierBuilder<String>(new StepVerifierOptions().initialRequest(Long.MAX_VALUE),
-					null, //important to avoid triggering of vts capture-and-enable
-					() -> vts)
+					new DefaultStepVerifierBuilder<String>(new StepVerifierOptions()
+							.initialRequest(Long.MAX_VALUE)
+							.virtualTimeSchedulerSupplier(() -> vts),
+					null)//important to avoid triggering of vts capture-and-enable
 					.thenAwait(Duration.ofSeconds(1))
 					.expectNext("foo")
 					.expectComplete()
@@ -93,9 +93,10 @@ public class DefaultStepVerifierBuilderTests {
 	public void suppliedVirtualTimeButNoSourceDoesntEnableScheduler() {
 		VirtualTimeScheduler vts = VirtualTimeScheduler.create();
 
-		new DefaultStepVerifierBuilder<String>(new StepVerifierOptions().initialRequest(Long.MAX_VALUE),
-							null, //important to avoid triggering of vts capture-and-enable
-							() -> vts)
+		new DefaultStepVerifierBuilder<String>(new StepVerifierOptions()
+				.initialRequest(Long.MAX_VALUE)
+				.virtualTimeSchedulerSupplier(() -> vts),
+				null) //important to avoid triggering of vts capture-and-enable
 							.expectNoEvent(Duration.ofSeconds(4))
 							.expectComplete()
 							.toSubscriber();

--- a/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
@@ -19,7 +19,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.LongAdder;
@@ -1611,6 +1610,14 @@ public class StepVerifierTests {
 				.isThrownBy(() -> validSoFar.thenConsumeWhile(s -> s == 1))
 				.withMessageStartingWith("The scenario will hang at thenConsumeWhile due to too little request being performed for the expectations to finish; ")
 	            .withMessageEndingWith("request remaining since last step: 0, expected: at least 1 (best effort estimation)");
+	}
+
+	@Test(timeout = 1000L)
+	public void lowRequestCheckCanBeDisabled() {
+		StepVerifier.create(Flux.just(1, 2),
+				new StepVerifierOptions().initialRequest(1).checkUnderRequesting(false))
+		            .expectNext(1)
+		            .thenConsumeWhile(s -> s == 1); //don't verify, this alone would throw an exception if check activated
 	}
 
 	@Test

--- a/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
@@ -1615,7 +1615,7 @@ public class StepVerifierTests {
 	@Test(timeout = 1000L)
 	public void lowRequestCheckCanBeDisabled() {
 		StepVerifier.create(Flux.just(1, 2),
-				new StepVerifierOptions().initialRequest(1).checkUnderRequesting(false))
+				StepVerifierOptions.create().initialRequest(1).checkUnderRequesting(false))
 		            .expectNext(1)
 		            .thenConsumeWhile(s -> s == 1); //don't verify, this alone would throw an exception if check activated
 	}


### PR DESCRIPTION
This allows to set options on a StepVerifier, for now the initial amount
to request and whether or not to disable to "under-request" check (which
can sometimes be wrong due / not see additional requests made internally
by some operators).