### PR TITLE
fix #88 StepVerifier's VirtualTimeScheduler activates for all by default

### DIFF
--- a/reactor-test/src/main/java/reactor/test/StepVerifier.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifier.java
@@ -147,7 +147,7 @@ public interface StepVerifier {
 	@Deprecated
 	static <T> FirstStep<T> withVirtualTime(long n,
 			Supplier<? extends Publisher<? extends T>> scenarioSupplier) {
-		return withVirtualTime(scenarioSupplier, () -> VirtualTimeScheduler.getOrSet(false), n);
+		return withVirtualTime(scenarioSupplier, () -> VirtualTimeScheduler.getOrSet(true), n);
 	}
 
 	/**
@@ -164,7 +164,7 @@ public interface StepVerifier {
 	 */
 	static <T> FirstStep<T> withVirtualTime(Supplier<? extends Publisher<? extends T>> scenarioSupplier,
 			long n) {
-		return withVirtualTime(scenarioSupplier, () -> VirtualTimeScheduler.getOrSet(false), n);
+		return withVirtualTime(scenarioSupplier, () -> VirtualTimeScheduler.getOrSet(true), n);
 	}
 
 	/**

--- a/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.LongAdder;
 
 import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Condition;
 import org.junit.Test;
 import reactor.core.Fuseable;
 import reactor.core.publisher.DirectProcessor;
@@ -44,6 +45,13 @@ import static reactor.test.publisher.TestPublisher.Violation.REQUEST_OVERFLOW;
  * @author Simon Baslé
  */
 public class StepVerifierTests {
+
+	/**
+	 * An AssertJ Condition that can be used to check if a {@link VirtualTimeScheduler} will
+	 * be used for all {@link Schedulers} factory methods once {@link VirtualTimeScheduler#set(VirtualTimeScheduler) set}.
+	 */
+	static final Condition<? super VirtualTimeScheduler> ENABLED_FOR_ALL = new Condition<>(
+			vts -> vts.isEnabledOnAllSchedulers(), "");
 
 	@Test
 	public void expectNext() {
@@ -1664,4 +1672,11 @@ public class StepVerifierTests {
 		assertThat(VirtualTimeScheduler.isFactoryEnabled()).isFalse();
 	}
 
+	@Test
+	public void defaultStepVerifierVTSIsEnabledForAll() {
+		StepVerifier.withVirtualTime(() -> Mono.just(1))
+		            .then(() -> assertThat(VirtualTimeScheduler.get()).is(ENABLED_FOR_ALL))
+	                .expectNext(1)
+	                .verifyComplete();
+	}
 }


### PR DESCRIPTION
This commit ensures the VirtualTimeScheduler created by StepVerifier
is activated on all schedulers of the SchedulerFactory by default,
instead of just the `timer()` previously. This is in preparation of a
change in core where all these Schedulers are time-capable and some
operator would use eg. parallel() as a default scheduler instead of
timer().

This can have side effects though, eg. when testing backpressure with
expectNoEvent and thenRequest, StepVerifier can run forever (if you're
not using the Duration variant). Adding a thenAwait after the request
will work around this issue.