### PR TITLE
Fix #101 empty multi-expectations consuming an onNext

### DIFF
--- a/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
@@ -690,6 +690,7 @@ final class DefaultStepVerifierBuilder<T>
 		Fuseable.QueueSubscription<T> qs;
 		long                          produced;   //used for request tracking
 		long                          unasserted; //used for expectNextXXX tracking
+		boolean                       reEvaluate; //used to loop again on the same signal when an expectation is effectively no-op
 		volatile long                 requested;
 		volatile boolean done; // async fusion
 		Iterator<? extends T>         currentNextAs;
@@ -835,7 +836,11 @@ final class DefaultStepVerifierBuilder<T>
 				}
 				Signal<T> signal = Signal.next(t);
 				if (!checkRequestOverflow(signal)) {
-					onExpectation(signal);
+					reEvaluate = true;
+					while (reEvaluate) {
+						reEvaluate = false;
+						onExpectation(signal);
+					}
 				}
 			}
 		}
@@ -1223,6 +1228,11 @@ final class DefaultStepVerifierBuilder<T>
 			Iterator<? extends T> currentNextAs = this.currentNextAs;
 			if (currentNextAs == null) {
 				currentNextAs = sequenceEvent.iterable.iterator();
+				if (actualSignal.isOnNext() && !currentNextAs.hasNext()) {
+					this.script.poll();
+					this.reEvaluate = true;
+					return true;
+				}
 				this.currentNextAs = currentNextAs;
 			}
 
@@ -1275,28 +1285,31 @@ final class DefaultStepVerifierBuilder<T>
 		}
 
 		final boolean onSignalCount(Signal<T> actualSignal, SignalCountEvent<T> event) {
-			if (unasserted >= event.count) {
+			if (event.count <= 0) {
+				this.script.poll();
+				this.reEvaluate = true;
+				return true;
+			}
+			else if (unasserted >= event.count) {
 				this.script.poll();
 				unasserted -= event.count;
+				return false;
 			}
-			else {
-				if (event.count != 0) {
-					Optional<AssertionError> error =
-							this.checkCountMismatch(event, actualSignal);
+			else { //event.count > 0
+				Optional<AssertionError> error =
+						this.checkCountMismatch(event, actualSignal);
 
-					if (error.isPresent()) {
-						Exceptions.addThrowable(ERRORS, this, error.get());
-						if(actualSignal.isOnError()) {
-							// #55 ensure the onError is added as a suppressed to the AssertionError
-							error.get().addSuppressed(actualSignal.getThrowable());
-						}
-						maybeCancel(actualSignal);
-						this.completeLatch.countDown();
+				if (error.isPresent()) {
+					Exceptions.addThrowable(ERRORS, this, error.get());
+					if(actualSignal.isOnError()) {
+						// #55 ensure the onError is added as a suppressed to the AssertionError
+						error.get().addSuppressed(actualSignal.getThrowable());
 					}
+					maybeCancel(actualSignal);
+					this.completeLatch.countDown();
 				}
 				return true;
 			}
-			return false;
 		}
 
 		void onTaskEvent() {

--- a/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
+++ b/reactor-test/src/test/java/reactor/test/StepVerifierTests.java
@@ -292,6 +292,15 @@ public class StepVerifierTests {
 	}
 
 	@Test
+	public void expectNextCountZeroThenValues() {
+		StepVerifier.create(Flux.just("foo", "bar"))
+		            .expectNextCount(0)
+		            .expectNext("foo", "bar")
+		            .expectComplete()
+		            .verify();
+	}
+
+	@Test
 	public void expectNextCountError() {
 		Flux<String> flux = Flux.just("foo", "bar");
 
@@ -544,7 +553,7 @@ public class StepVerifierTests {
 	}
 
 	@Test
-	public void verifyNextAsWithEmptyFlux() {
+	public void verifyNextAsErrorEmptyFlux() {
 	    final List<Integer> source = Arrays.asList(1,2,3);
 		Flux<Integer> flux = Flux.empty();
 
@@ -555,6 +564,44 @@ public class StepVerifierTests {
 				.verify())
                 .withMessageStartingWith("expectation \"expectNextSequence\" failed (")
                 .withMessageEndingWith("expected next value: 1; actual signal: onComplete(); iterable: [1, 2, 3])");;
+	}
+
+	@Test
+	public void verifyNextAsErrorEmptyIterable() {
+	    final List<Integer> expected = Collections.emptyList();
+		Flux<Integer> flux = Flux.just(1, 2, 3);
+
+		assertThatExceptionOfType(AssertionError.class)
+				.isThrownBy(() -> StepVerifier.create(flux)
+				                              .expectNextSequence(expected)
+				                              .expectComplete()
+				                              .verify())
+				.withMessageStartingWith("expectation \"expectComplete\" failed (")
+				.withMessageEndingWith("expected: onComplete(); actual: onNext(1))");;
+	}
+
+	@Test
+	public void verifyNextCountErrorZeroCount() {
+		Flux<Integer> flux = Flux.just(1, 2, 3);
+
+		assertThatExceptionOfType(AssertionError.class)
+				.isThrownBy(() -> StepVerifier.create(flux)
+				                              .expectNextCount(0L)
+				                              .expectComplete()
+				                              .verify())
+				.withMessageStartingWith("expectation \"expectComplete\" failed (")
+				.withMessageEndingWith("expected: onComplete(); actual: onNext(1))");;
+	}
+
+	@Test
+	public void verifyNextAsEmptyFluxEmptyIterable() {
+		final List<Integer> expected = Collections.emptyList();
+		Flux<Integer> flux = Flux.empty();
+
+		StepVerifier.create(flux)
+		            .expectNextSequence(expected)
+		            .expectComplete()
+		            .verify();
 	}
 
 	@Test


### PR DESCRIPTION
`expectNextCount(0)` and `expectNextSequence(empty)` should basically
be no-op, but instead they still count as a pass and thus skip 1
onNext signal.