### PR TITLE
Overload Step#expectNext

### DIFF
--- a/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
@@ -345,13 +345,6 @@ final class DefaultStepVerifierBuilder<T>
 		return this;
 	}
 
-	@Override
-	public final DefaultStepVerifierBuilder<T> expectNext(List<T> ts) {
-		Objects.requireNonNull(ts, "ts");
-		ts.forEach(this::addExpectedValue);
-		return this;
-	}
-
 	@SuppressWarnings("unchecked") // cast to a known type
 	private DefaultStepVerifierBuilder<T> addExpectedValues(Object[] values) {
 		Arrays.stream(values).map(val -> (T) val).forEach(this::addExpectedValue);

--- a/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
+++ b/reactor-test/src/main/java/reactor/test/DefaultStepVerifierBuilder.java
@@ -49,6 +49,7 @@ import reactor.core.Fuseable;
 import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Operators;
 import reactor.core.publisher.Signal;
+import reactor.test.StepVerifier.Step;
 import reactor.test.scheduler.VirtualTimeScheduler;
 import reactor.util.Logger;
 import reactor.util.Loggers;
@@ -307,28 +308,71 @@ final class DefaultStepVerifierBuilder<T>
 	}
 
 	@Override
+	public final DefaultStepVerifierBuilder<T> expectNext(T t) {
+		return addExpectedValues(new Object[] { t });
+	}
+
+	@Override
+	public final DefaultStepVerifierBuilder<T> expectNext(T t1, T t2) {
+		return addExpectedValues(new Object[] { t1, t2 });
+	}
+
+	@Override
+	public final DefaultStepVerifierBuilder<T> expectNext(T t1, T t2, T t3) {
+		return addExpectedValues(new Object[] { t1, t2, t3 });
+	}
+
+	@Override
+	public final DefaultStepVerifierBuilder<T> expectNext(T t1, T t2, T t3, T t4) {
+		return addExpectedValues(new Object[] { t1, t2, t3, t4 });
+	}
+
+	@Override
+	public final DefaultStepVerifierBuilder<T> expectNext(T t1, T t2, T t3, T t4, T t5) {
+		return addExpectedValues(new Object[] { t1, t2, t3, t4, t5 });
+	}
+
+	@Override
+	public final DefaultStepVerifierBuilder<T> expectNext(T t1, T t2, T t3, T t4, T t5, T t6) {
+		return addExpectedValues(new Object[] { t1, t2, t3, t4, t5, t6 });
+	}
+
+	@Override
 	@SafeVarargs
 	public final DefaultStepVerifierBuilder<T> expectNext(T... ts) {
 		Objects.requireNonNull(ts, "ts");
-		SignalEvent<T> event;
-		for (T t : ts) {
-			String desc = String.format("expectNext(%s)", t);
-			checkPotentialHang(1, desc);
-			event = new SignalEvent<>((signal, se) -> {
-				if (!signal.isOnNext()) {
-					return fail(se, "expected: onNext(%s); actual: %s", t, signal);
-				}
-				else if (!Objects.equals(t, signal.get())) {
-					return fail(se, "expected value: %s; actual value: %s", t, signal.get());
-
-				}
-				else {
-					return Optional.empty();
-				}
-			}, desc);
-			this.script.add(event);
-		}
+		Arrays.stream(ts).forEach(this::addExpectedValue);
 		return this;
+	}
+
+	@Override
+	public final DefaultStepVerifierBuilder<T> expectNext(List<T> ts) {
+		Objects.requireNonNull(ts, "ts");
+		ts.forEach(this::addExpectedValue);
+		return this;
+	}
+
+	@SuppressWarnings("unchecked") // cast to a known type
+	private DefaultStepVerifierBuilder<T> addExpectedValues(Object[] values) {
+		Arrays.stream(values).map(val -> (T) val).forEach(this::addExpectedValue);
+		return this;
+	}
+
+	private void addExpectedValue(T value) {
+		String desc = String.format("expectNext(%s)", value);
+		checkPotentialHang(1, desc);
+		SignalEvent<T> event = new SignalEvent<>((signal, se) -> {
+			if (!signal.isOnNext()) {
+				return fail(se, "expected: onNext(%s); actual: %s", value, signal);
+			}
+			else if (!Objects.equals(value, signal.get())) {
+				return fail(se, "expected value: %s; actual value: %s", value, signal.get());
+			}
+			else {
+				return Optional.empty();
+			}
+		}, desc);
+		this.script.add(event);
 	}
 
 	@Override
@@ -1747,7 +1791,7 @@ final class DefaultStepVerifierBuilder<T>
 	static class SubscriptionEvent<T> extends AbstractEagerEvent<T> {
 
 		final Consumer<Subscription> consumer;
-		
+
 		SubscriptionEvent(String desc) {
 			this(null, desc);
 		}
@@ -1885,7 +1929,7 @@ final class DefaultStepVerifierBuilder<T>
 	static class TaskEvent<T> extends AbstractEagerEvent<T> {
 
 		final Runnable task;
-		
+
 		TaskEvent(Runnable task, String desc) {
 			super(desc);
 			this.task = task;

--- a/reactor-test/src/main/java/reactor/test/StepVerifier.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifier.java
@@ -595,17 +595,6 @@ public interface StepVerifier {
 		Step<T> expectNext(T... ts);
 
 		/**
-		 * Expect the next elements received to be equal to the given values.
-		 *
-		 * @param ts the values to expect
-		 *
-		 * @return this builder
-		 *
-		 * @see Subscriber#onNext(Object)
-		 */
-		Step<T> expectNext(List<T> ts);
-
-		/**
 		 * Expect to received {@code count} elements, starting from the previous
 		 * expectation or onSubscribe.
 		 *

--- a/reactor-test/src/main/java/reactor/test/StepVerifier.java
+++ b/reactor-test/src/main/java/reactor/test/StepVerifier.java
@@ -18,6 +18,7 @@ package reactor.test;
 
 import java.time.Duration;
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -502,6 +503,87 @@ public interface StepVerifier {
 		Step<T> consumeRecordedWith(Consumer<? super Collection<T>> consumer);
 
 		/**
+		 * Expect the next element received to be equal to the given value.
+		 *
+		 * @param t the value to expect
+		 *
+		 * @return this builder
+		 *
+		 * @see Subscriber#onNext(Object)
+		 */
+		Step<T> expectNext(T t);
+
+		/**
+		 * Expect the next elements received to be equal to the given values.
+		 *
+		 * @param t1 the first value to expect
+		 * @param t2 the second value to expect
+		 *
+		 * @return this builder
+		 *
+		 * @see Subscriber#onNext(Object)
+		 */
+		Step<T> expectNext(T t1, T t2);
+
+		/**
+		 * Expect the next elements received to be equal to the given values.
+		 *
+		 * @param t1 the first value to expect
+		 * @param t2 the second value to expect
+		 * @param t3 the third value to expect
+		 *
+		 * @return this builder
+		 *
+		 * @see Subscriber#onNext(Object)
+		 */
+		Step<T> expectNext(T t1, T t2, T t3);
+
+		/**
+		 * Expect the next elements received to be equal to the given values.
+		 *
+		 * @param t1 the first value to expect
+		 * @param t2 the second value to expect
+		 * @param t3 the third value to expect
+		 * @param t4 the fourth value to expect
+		 *
+		 * @return this builder
+		 *
+		 * @see Subscriber#onNext(Object)
+		 */
+		Step<T> expectNext(T t1, T t2, T t3, T t4);
+
+		/**
+		 * Expect the next elements received to be equal to the given values.
+		 *
+		 * @param t1 the first value to expect
+		 * @param t2 the second value to expect
+		 * @param t3 the third value to expect
+		 * @param t4 the fourth value to expect
+		 * @param t5 the fifth value to expect
+		 *
+		 * @return this builder
+		 *
+		 * @see Subscriber#onNext(Object)
+		 */
+		Step<T> expectNext(T t1, T t2, T t3, T t4, T t5);
+
+		/**
+		 * Expect the next elements received to be equal to the given values.
+		 *
+		 * @param t1 the first value to expect
+		 * @param t2 the second value to expect
+		 * @param t3 the third value to expect
+		 * @param t4 the fourth value to expect
+		 * @param t5 the fifth value to expect
+		 * @param t6 the sixth value to expect
+		 *
+		 * @return this builder
+		 *
+		 * @see Subscriber#onNext(Object)
+		 */
+		Step<T> expectNext(T t1, T t2, T t3, T t4, T t5, T t6);
+
+		/**
 		 * Expect the next elements received to be equal to the given values.
 		 *
 		 * @param ts the values to expect
@@ -511,6 +593,17 @@ public interface StepVerifier {
 		 * @see Subscriber#onNext(Object)
 		 */
 		Step<T> expectNext(T... ts);
+
+		/**
+		 * Expect the next elements received to be equal to the given values.
+		 *
+		 * @param ts the values to expect
+		 *
+		 * @return this builder
+		 *
+		 * @see Subscriber#onNext(Object)
+		 */
+		Step<T> expectNext(List<T> ts);
 
 		/**
 		 * Expect to received {@code count} elements, starting from the previous


### PR DESCRIPTION
I found myself having to use `@SuppressWarnings("unchecked")` on all of my test methods because of the generic varargs array creation. For most use cases (where people are checking 1-6 values), this change obviates the need for the annotation.

Ideally I would have made these default methods, but unfortunately that's not possible (as far as I can tell). 