### PR TITLE
Upgrade to RxJava 2.1, fix Flowable conversions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ ext {
 
   // Libraries
   openHftChronicleVersion = '3.4.2'
-  rxJava2Version = '2.0.0'
+  rxJava2Version = '2.1.0'
   akkaActorVersion = '2.4.10'
 
   swtVersion = '4.5.2'

--- a/reactor-adapter/src/main/java/reactor/adapter/rxjava/RxJava2Adapter.java
+++ b/reactor-adapter/src/main/java/reactor/adapter/rxjava/RxJava2Adapter.java
@@ -151,9 +151,9 @@ public abstract class RxJava2Adapter {
     
     static final class FlowableAsFlux<T> extends Flux<T> implements Fuseable {
         
-        final Publisher<T> source;
+        final Flowable<T> source;
         
-        public FlowableAsFlux(Publisher<T> source) {
+        public FlowableAsFlux(Flowable<T> source) {
             this.source = source;
         }
         
@@ -166,7 +166,7 @@ public abstract class RxJava2Adapter {
             }
         }
         
-        static final class FlowableAsFluxSubscriber<T> implements Subscriber<T>, QueueSubscription<T> {
+        static final class FlowableAsFluxSubscriber<T> implements FlowableSubscriber<T>, QueueSubscription<T> {
             
             final Subscriber<? super T> actual;
 
@@ -250,7 +250,7 @@ public abstract class RxJava2Adapter {
         }
         
         static final class FlowableAsFluxConditionalSubscriber<T> implements 
-        ConditionalSubscriber<T>, QueueSubscription<T> {
+        io.reactivex.internal.fuseable.ConditionalSubscriber<T>, QueueSubscription<T> {
             
             final ConditionalSubscriber<? super T> actual;
 


### PR DESCRIPTION
- Upgrade the RxJava dependency to 2.1.0
- Use `FlowableSubscriber` to not incur the spec overhead between the two libraries
- Use `Flowable` as target in the wrapper to avoid `instanceof` with the spec `subscribe` call
- `FlowableAsFluxConditionalSubscriber` subscribes to a `Flowable` and thus has to present itself as an RxJava 2 `ConditionalSubscriber`, not a Reactor 3 one