### PR TITLE
scheduler based on fork join pool

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ ext {
   swtVersionPlatform = '4.5.2'
 
   // Testing
+  assertJVersion = '3.6.1'
   mockitoVersion = '1.10.19'
   spockVersion = '1.0-groovy-2.4'
 
@@ -161,6 +162,7 @@ configure(subprojects) { project ->
 	// Testing
 	testCompile 'junit:junit:4.12',
 			"org.hamcrest:hamcrest-library:1.3",
+			"org.assertj:assertj-core:$assertJVersion",
 			"org.testng:testng:6.8.5"
 	testRuntime "ch.qos.logback:logback-classic:$logbackVersion"
 	testCompile "io.projectreactor:reactor-test:$version"

--- a/reactor-extra/src/main/java/reactor/scheduler/forkjoin/ForkJoinPoolScheduler.java
+++ b/reactor-extra/src/main/java/reactor/scheduler/forkjoin/ForkJoinPoolScheduler.java
@@ -1,0 +1,497 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.scheduler.forkjoin;
+
+import java.util.ArrayDeque;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinTask;
+import java.util.concurrent.ForkJoinWorkerThread;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiConsumer;
+import java.util.function.BooleanSupplier;
+
+import reactor.core.Disposable;
+import reactor.core.Exceptions;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.Logger;
+import reactor.util.Loggers;
+
+import static reactor.core.Exceptions.unwrap;
+
+public final class ForkJoinPoolScheduler implements Scheduler {
+
+	private static volatile BiConsumer<Thread, ? super Throwable> onHandleErrorHook;
+
+	/**
+	 * {@link Scheduler} that hosts a fixed pool of single-threaded ExecutorService-based
+	 * workers and is suited for parallel work.
+	 *
+	 * @param name Thread prefix
+	 *
+	 * @return a new {@link Scheduler} that hosts a fixed pool of single-threaded
+	 * ExecutorService-based workers and is suited for parallel work
+	 */
+	public static Scheduler create(String name) {
+		return create(name,
+				Runtime.getRuntime()
+				       .availableProcessors());
+	}
+
+	/**
+	 * {@link Scheduler} that utilizes a {@link java.util.concurrent.ForkJoinPool} for
+	 * workers and is suited for parallel work. Since the ForkJoinPool does not support
+	 * periodic or delayed scheduling, a single Scheduler is used to
+	 * enqueue any tasks that are delayed or periodic
+	 *
+	 * @param name Thread prefix
+	 * @param parallelism Number of worker threads
+	 *
+	 * @return a new {@link Scheduler} that utilizes a ForkJoinPool
+	 */
+	public static Scheduler create(String name, int parallelism) {
+		return new ForkJoinPoolScheduler(parallelism,
+				new SchedulerForkJoinWorkerThreadFactory(name, COUNTER),
+				Schedulers.newSingle(name + "-timer", true),
+				true);
+
+	}
+
+	/**
+	 * {@link Scheduler} that utilizes a {@link java.util.concurrent.ForkJoinPool} for
+	 * workers and is suited for parallel work. Since the ForkJoinPool does not support
+	 * periodic or delayed scheduling, a single Scheduler is used to
+	 * enqueue any tasks that are delayed or periodic
+	 *
+	 * @param parallelism Number of worker threads
+	 * @param workerThreadFactory factory for ForkJoinPool thrads
+	 * @param timeScheduler Scheduler to use for timed tasks
+	 *
+	 * @return a new {@link Scheduler} that utilizes a ForkJoinPool
+	 */
+	public static Scheduler create(int parallelism,
+			ForkJoinPool.ForkJoinWorkerThreadFactory workerThreadFactory,
+			Scheduler timeScheduler) {
+		return new ForkJoinPoolScheduler(parallelism,
+				workerThreadFactory,
+				timeScheduler,
+				false);
+	}
+
+	static void handleError(Throwable ex) {
+		Thread thread = Thread.currentThread();
+		Throwable t = unwrap(ex);
+		Exceptions.throwIfJvmFatal(t);
+		Thread.UncaughtExceptionHandler x = thread.getUncaughtExceptionHandler();
+		if (x != null) {
+			x.uncaughtException(thread, t);
+		}
+		else {
+			log.error("Scheduler worker failed with an uncaught exception", t);
+		}
+		if (onHandleErrorHook != null) {
+			onHandleErrorHook.accept(thread, t);
+		}
+	}
+
+	/**
+	 * Define a hook that is executed when a {@link Scheduler} has
+	 * {@link #handleError(Throwable) handled an error}. Note that it is executed after
+	 * the error has been passed to the thread uncaughtErrorHandler, which is not the
+	 * case when a fatal error occurs (see {@link Exceptions#throwIfJvmFatal(Throwable)}).
+	 *
+	 * @param c the new hook to set.
+	 */
+	public static void onHandleError(BiConsumer<Thread, ? super Throwable> c) {
+		log.info("Hooking new: onHandleError");
+		onHandleErrorHook = Objects.requireNonNull(c, "onHandleError");
+	}
+
+	/**
+	 * Reset the {@link #onHandleError(BiConsumer)} hook to the default no-op behavior.
+	 */
+	public static void resetOnHandleError() {
+		log.info("Reset to default: onHandleError");
+		onHandleErrorHook = null;
+	}
+
+	private final ForkJoinPool pool;
+	private final Scheduler    scheduler;
+	private final boolean      disposeScheduler;
+
+	/**
+	 * Construct a new instance
+	 *
+	 * @param parallelism Parallelism. Number of fork-join pool threads. See {@link
+	 * ForkJoinPool}
+	 * @param workerThreadFactory Thread factory for fork-join worker threads
+	 * @param scheduler Scheduler to use for time-based scheduling
+	 */
+	private ForkJoinPoolScheduler(int parallelism,
+			ForkJoinPool.ForkJoinWorkerThreadFactory workerThreadFactory,
+			Scheduler scheduler,
+			boolean disposeScheduler) {
+		this.pool = new ForkJoinPool(parallelism,
+				workerThreadFactory,
+				this::uncaughtException,
+				true);
+		this.scheduler = scheduler;
+		this.disposeScheduler = disposeScheduler;
+	}
+
+	@Override
+	public Scheduler.Worker createWorker() {
+		return new Worker(pool, scheduler);
+	}
+
+	@Override
+	public void dispose() {
+		if (disposeScheduler) {
+			scheduler.dispose();
+		}
+		pool.shutdownNow();
+	}
+
+	@Override
+	public boolean isDisposed() {
+		return pool.isShutdown();
+	}
+
+	@Override
+	public Disposable schedule(Runnable runnable) {
+		try {
+			return new DisposableForkJoinTask(pool.submit(runnable));
+		}
+		catch (RejectedExecutionException ignored) {
+			return REJECTED;
+		}
+	}
+
+	@Override
+	public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
+		if (delay == 0) {
+			return schedule(task);
+		}
+		TrampolinedTask trampolinedTask = new TrampolinedTask(pool, task, NO_PARENT);
+		Disposable scheduled = scheduler.schedule(trampolinedTask, delay, unit);
+		if(scheduled == Scheduler.REJECTED) {
+			return scheduled;
+		}
+		return new CompositeDisposable(scheduled, trampolinedTask);
+	}
+
+	@Override
+	public Disposable schedulePeriodically(Runnable task,
+			long initialDelay,
+			long period,
+			TimeUnit unit) {
+		TrampolinedTask trampolinedTask = new TrampolinedTask(pool, task, NO_PARENT);
+		Disposable scheduled = scheduler.schedulePeriodically(trampolinedTask,
+				initialDelay,
+				period,
+				unit);
+		if(scheduled == Scheduler.REJECTED) {
+			return scheduled;
+		}
+		return new CompositeDisposable(scheduled, trampolinedTask);
+	}
+
+	private void uncaughtException(Thread t, Throwable e) {
+		log.error("Scheduler worker in group " + t.getThreadGroup()
+		                                          .getName() + " failed with an uncaught exception",
+				e);
+	}
+
+	private static class DisposableForkJoinTask implements Disposable {
+
+		private final ForkJoinTask<?> task;
+
+		DisposableForkJoinTask(ForkJoinTask<?> task) {
+			this.task = task;
+		}
+
+		@Override
+		public void dispose() {
+			task.cancel(false);
+		}
+
+		@Override
+		public boolean isDisposed() {
+			return task.isDone();
+		}
+	}
+
+	private static class TrampolinedTask implements Runnable, Disposable {
+
+		private final    Executor        executor;
+		private final    Runnable        task;
+		private final    BooleanSupplier isParentDisposed;
+		private volatile boolean         disposed;
+
+		public TrampolinedTask(Executor executor,
+				Runnable task,
+				BooleanSupplier isParentDisposed) {
+			this.executor = executor;
+			this.task = task;
+			this.isParentDisposed = isParentDisposed;
+		}
+
+		@Override
+		public void dispose() {
+			disposed = true;
+		}
+
+		@Override
+		public boolean isDisposed() {
+			return disposed || isParentDisposed.getAsBoolean();
+		}
+
+		@Override
+		public void run() {
+			executor.execute(() -> {
+				if (!isDisposed()) {
+					task.run();
+				}
+			});
+		}
+	}
+
+	static final class CompositeDisposable implements Disposable {
+
+		final Disposable a;
+		final Disposable b;
+
+		CompositeDisposable(Disposable a, Disposable b) {
+			this.a = a;
+			this.b = b;
+		}
+
+		@Override
+		public void dispose() {
+			a.dispose();
+			b.dispose();
+		}
+
+		@Override
+		public boolean isDisposed() {
+			return a.isDisposed() && b.isDisposed();
+		}
+	}
+
+	private static class Worker implements Scheduler.Worker {
+
+		private final Executor  executor;
+		private final Scheduler scheduler;
+		private final Object          lock             = new Object();
+		private final Queue<Runnable> tasks            = new ArrayDeque<>();
+		private       boolean         executing        = false;
+		private final Runnable        processTaskQueue = this::processTaskQueue;
+		private final Executor        workerExecutor   = this::execute;
+		private volatile boolean shutdown;
+		private final BooleanSupplier isDisposed = this::isDisposed;
+
+		Worker(Executor executor, Scheduler scheduler) {
+			this.executor = executor;
+			this.scheduler = scheduler;
+		}
+
+		@Override
+		public void dispose() {
+			if (shutdown) {
+				return;
+			}
+
+			shutdown = true;
+
+			synchronized (lock) {
+				tasks.clear();
+			}
+		}
+
+		@Override
+		public boolean isDisposed() {
+			return shutdown;
+		}
+
+		@Override
+		public Disposable schedule(Runnable task) {
+			if (shutdown) {
+				return REJECTED;
+			}
+
+			DisposableWorkerTask workerTask = new DisposableWorkerTask(task, isDisposed);
+
+			try {
+				execute(workerTask);
+			}
+			catch (RejectedExecutionException ignored) {
+				// dispose the task since it made it into the queue
+				workerTask.dispose();
+				return REJECTED;
+			}
+
+			return workerTask;
+		}
+
+		@Override
+		public Disposable schedule(Runnable task, long delay, TimeUnit unit) {
+			if (delay == 0) {
+				return schedule(task);
+			}
+
+			if (shutdown) {
+				return REJECTED;
+			}
+
+			TrampolinedTask trampolinedTask =
+					new TrampolinedTask(workerExecutor, task, isDisposed);
+			Disposable scheduled = scheduler.schedule(trampolinedTask, delay, unit);
+			if(scheduled == Scheduler.REJECTED) {
+				return scheduled;
+			}
+			return new CompositeDisposable(scheduled, trampolinedTask);
+		}
+
+		@Override
+		public Disposable schedulePeriodically(Runnable task,
+				long initialDelay,
+				long period,
+				TimeUnit unit) {
+			if (shutdown) {
+				return REJECTED;
+			}
+
+			TrampolinedTask trampolinedTask =
+					new TrampolinedTask(workerExecutor, task, isDisposed);
+
+			Disposable scheduled = scheduler.schedulePeriodically(trampolinedTask,
+					initialDelay,
+					period,
+					unit);
+			if(scheduled == Scheduler.REJECTED) {
+				return scheduled;
+			}
+			return new CompositeDisposable(scheduled, trampolinedTask);
+		}
+
+		private void execute(Runnable command) {
+			boolean schedule;
+			synchronized (lock) {
+				tasks.add(command);
+
+				if (executing) {
+					schedule = false;
+				}
+				else {
+					executing = true;
+					schedule = true;
+				}
+			}
+
+			if (schedule) {
+				executor.execute(processTaskQueue);
+			}
+		}
+
+		private void processTaskQueue() {
+			while (true) {
+				Runnable task;
+				synchronized (lock) {
+					task = tasks.poll();
+					if (task == null) {
+						executing = false;
+						return;
+					}
+				}
+
+				try {
+					task.run();
+				}
+				catch (Throwable ex) {
+					handleError(ex);
+				}
+			}
+		}
+	}
+
+	private static class DisposableWorkerTask implements Disposable, Runnable {
+
+		private final    Runnable        task;
+		private final    BooleanSupplier isParentDisposed;
+		private volatile boolean         disposed;
+
+		private DisposableWorkerTask(Runnable task, BooleanSupplier disposed) {
+			this.task = task;
+			isParentDisposed = disposed;
+		}
+
+		@Override
+		public void dispose() {
+			disposed = true;
+		}
+
+		@Override
+		public boolean isDisposed() {
+			return disposed || isParentDisposed.getAsBoolean();
+		}
+
+		@Override
+		public void run() {
+			if (isDisposed()) {
+				return;
+			}
+
+			task.run();
+		}
+	}
+
+	private static final class SchedulerForkJoinWorkerThread
+			extends ForkJoinWorkerThread {
+
+		SchedulerForkJoinWorkerThread(String name, ForkJoinPool pool) {
+			super(pool);
+			setName(name);
+		}
+	}
+
+	private static final class SchedulerForkJoinWorkerThreadFactory
+			implements ForkJoinPool.ForkJoinWorkerThreadFactory {
+
+		final String     name;
+		final AtomicLong COUNTER;
+
+		SchedulerForkJoinWorkerThreadFactory(String name, AtomicLong COUNTER) {
+			this.name = name;
+			this.COUNTER = COUNTER;
+		}
+
+		@Override
+		public ForkJoinWorkerThread newThread(ForkJoinPool pool) {
+			return new SchedulerForkJoinWorkerThread(name + "-" + COUNTER.incrementAndGet(),
+					pool);
+		}
+	}
+
+	private static final AtomicLong      COUNTER   = new AtomicLong();
+	private static final Logger          log       = Loggers.getLogger(Schedulers.class);
+	private static final BooleanSupplier NO_PARENT = () -> false;
+}

--- a/reactor-extra/src/test/java/reactor/scheduler/forkjoin/AbstractSchedulerTest.java
+++ b/reactor-extra/src/test/java/reactor/scheduler/forkjoin/AbstractSchedulerTest.java
@@ -1,0 +1,381 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reactor.scheduler.forkjoin;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.assertj.core.api.Condition;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+import reactor.core.Disposable;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Stephane Maldini
+ */
+public abstract class AbstractSchedulerTest {
+
+	static final Condition<Scheduler> DISPOSED =
+			new Condition<>(Disposable::isDisposed,
+			"a %s scheduler", "disposed");
+
+	protected abstract Scheduler scheduler();
+
+	protected boolean shouldCheckInterrupted(){
+		return false;
+	}
+
+	protected boolean shouldCheckDisposeTask(){
+		return true;
+	}
+
+	protected boolean shouldCheckMassWorkerDispose(){
+		return true;
+	}
+
+	protected boolean shouldCheckDirectTimeScheduling() { return true; }
+
+	protected boolean shouldCheckWorkerTimeScheduling() { return true; }
+
+	@Test(timeout = 10000)
+	final public void directScheduleAndDispose() throws Exception {
+		Scheduler s = scheduler();
+
+		try {
+			assertThat(s.isDisposed()).isFalse();
+			CountDownLatch latch = new CountDownLatch(1);
+			CountDownLatch latch2 = shouldCheckDisposeTask() ? new CountDownLatch(1)
+					: null;
+			Disposable c = s.schedule(() -> {
+				try{
+					latch.countDown();
+					if(latch2 != null && !latch2.await(10, TimeUnit.SECONDS) &&
+							shouldCheckInterrupted()){
+						Assert.fail("Should have interrupted");
+					}
+				}
+				catch (InterruptedException e){
+				}
+			});
+			Disposable d = c;
+
+			latch.await();
+			if(shouldCheckDisposeTask()) {
+				assertThat(d.isDisposed()).isFalse();
+			}
+			else{
+				d.isDisposed(); //noop
+			}
+			d.dispose();
+			d.dispose();//noop
+
+			Thread.yield();
+
+			if(latch2 != null) {
+				latch2.countDown();
+			}
+
+
+			s.dispose();
+			s.dispose();//noop
+
+			assertThat(s.isDisposed()).isTrue();
+
+			c = s.schedule(() -> {
+				if(shouldCheckInterrupted()){
+					try {
+						Thread.sleep(10000);
+					}
+					catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+					}
+				}
+			});
+
+			d = c;
+			assertThat(c).isEqualTo(Scheduler.REJECTED);
+			d.dispose();
+			assertThat(d.isDisposed()).isTrue();
+		}
+		finally {
+			s.dispose();
+			s.dispose();//noop
+		}
+	}
+
+	@Test(timeout = 10000)
+	final public void workerScheduleAndDispose() throws Exception {
+		Scheduler s = scheduler();
+		try {
+			Scheduler.Worker w = s.createWorker();
+
+			assertThat(w.isDisposed()).isFalse();
+			CountDownLatch latch = new CountDownLatch(1);
+			CountDownLatch latch2 = shouldCheckDisposeTask() ? new CountDownLatch(1)
+					: null;
+			Disposable c = w.schedule(() -> {
+				try{
+					latch.countDown();
+					if(latch2 != null && !latch2.await(10, TimeUnit.SECONDS) &&
+							shouldCheckInterrupted()){
+						Assert.fail("Should have interrupted");
+					}
+				}
+				catch (InterruptedException e){
+				}
+			});
+			Disposable d = c;
+
+			latch.await();
+			if(shouldCheckDisposeTask()) {
+				assertThat(d.isDisposed()).isFalse();
+			}
+			d.dispose();
+			d.dispose();//noop
+
+			Thread.yield();
+
+			if(latch2 != null) {
+				latch2.countDown();
+			}
+
+			Disposable[] massCancel;
+			if(shouldCheckMassWorkerDispose()) {
+				int n = 10;
+				massCancel = new Disposable[n];
+				Thread current = Thread.currentThread();
+				for(int i = 0; i< n; i++){
+					massCancel[i] = w.schedule(() -> {
+						if(current == Thread.currentThread()){
+							return;
+						}
+						try{
+							Thread.sleep(5000);
+						}
+						catch (InterruptedException ie){
+
+						}
+					});
+				}
+			}
+			else{
+				massCancel = null;
+			}
+			w.dispose();
+			w.dispose(); //noop
+			assertThat(w.isDisposed()).isTrue();
+
+			if(massCancel != null){
+				for(Disposable _d : massCancel){
+					assertThat(_d.isDisposed()).isTrue();
+				}
+			}
+
+			c = w.schedule(() -> {});
+			d = c;
+
+			assertThat(c).isEqualTo(Scheduler.REJECTED);
+			assertThat(d.isDisposed()).isTrue();
+		}
+		finally {
+			s.dispose();
+			s.dispose();//noop
+		}
+	}
+
+	@Test(timeout = 10000)
+	final public void directScheduleAndDisposeDelay() throws Exception {
+		Assume.assumeTrue("Scheduler marked as not supporting time scheduling", shouldCheckDirectTimeScheduling());
+		Scheduler s = scheduler();
+
+		try {
+			assertThat(s.isDisposed()).isFalse();
+			CountDownLatch latch = new CountDownLatch(1);
+			CountDownLatch latch2 = new CountDownLatch(1);
+			Disposable d = s.schedule(() -> {
+				try {
+					latch.countDown();
+					latch2.await(10, TimeUnit.SECONDS);
+				}
+				catch (InterruptedException e) {
+				}
+			}, 10, TimeUnit.MILLISECONDS);
+			assertThat(d).isNotSameAs(Scheduler.REJECTED);
+
+			latch.await();
+			assertThat(d.isDisposed()).isFalse();
+			d.dispose();
+
+			Thread.yield();
+
+			latch2.countDown();
+
+			s.dispose();
+			assertThat(s).is(DISPOSED);
+
+			d = s.schedule(() -> { });
+
+			assertThat(d).isSameAs(Scheduler.REJECTED);
+			d.dispose();
+			assertThat(d.isDisposed()).isTrue();
+		}
+		finally {
+			s.dispose();
+		}
+	}
+
+	@Test(timeout = 10000)
+	final public void workerScheduleAndDisposeDelay() throws Exception {
+		Assume.assumeTrue("Worker marked as not supporting time scheduling", shouldCheckWorkerTimeScheduling());
+		Scheduler s = scheduler();
+		Scheduler.Worker w = s.createWorker();
+
+		try {
+
+			assertThat(w.isDisposed()).isFalse();
+			CountDownLatch latch = new CountDownLatch(1);
+			CountDownLatch latch2 = new CountDownLatch(1);
+			Disposable d = w.schedule(() -> {
+				try {
+					latch.countDown();
+					latch2.await(10, TimeUnit.SECONDS);
+				}
+				catch (InterruptedException e) {
+				}
+			}, 10, TimeUnit.MILLISECONDS);
+			assertThat(d).isNotSameAs(Scheduler.REJECTED);
+
+			latch.await();
+			assertThat(d.isDisposed()).isFalse();
+			d.dispose();
+
+			Thread.yield();
+
+			latch2.countDown();
+
+			w.dispose();
+			assertThat(w.isDisposed()).isTrue();
+
+			d = w.schedule(() -> { });
+
+			assertThat(d).isEqualTo(Scheduler.REJECTED);
+			assertThat(d.isDisposed()).isTrue();
+			d.dispose();
+			assertThat(d.isDisposed()).isTrue();
+		}
+		finally {
+			w.dispose();
+			s.dispose();
+		}
+	}
+
+	@Test(timeout = 10000)
+	final public void directScheduleAndDisposePeriod() throws Exception {
+		Assume.assumeTrue("Scheduler marked as not supporting time scheduling", shouldCheckDirectTimeScheduling());
+		Scheduler s = scheduler();
+
+		try {
+			assertThat(s.isDisposed()).isFalse();
+			CountDownLatch latch = new CountDownLatch(2);
+			CountDownLatch latch2 = new CountDownLatch(1);
+			Disposable d = s.schedulePeriodically(() -> {
+				try {
+					latch.countDown();
+					if (latch.getCount() == 0) {
+						latch2.await(10, TimeUnit.SECONDS);
+					}
+				}
+				catch (InterruptedException e) {
+				}
+			}, 10, 10, TimeUnit.MILLISECONDS);
+			assertThat(d).isNotSameAs(Scheduler.REJECTED);
+
+			assertThat(d.isDisposed()).isFalse();
+
+			latch.await();
+			d.dispose();
+
+			Thread.yield();
+
+			latch2.countDown();
+
+			s.dispose();
+			assertThat(s).is(DISPOSED);
+
+			d = s.schedule(() -> { });
+
+			d.dispose();
+			assertThat(d.isDisposed()).isTrue();
+		}
+		finally {
+			s.dispose();
+		}
+	}
+
+	@Test(timeout = 10000)
+	final public void workerScheduleAndDisposePeriod() throws Exception {
+		Assume.assumeTrue("Worker marked as not supporting time scheduling", shouldCheckWorkerTimeScheduling());
+		Scheduler s = scheduler();
+		Scheduler.Worker w = s.createWorker();
+
+		try {
+
+			assertThat(w.isDisposed()).isFalse();
+			CountDownLatch latch = new CountDownLatch(1);
+			CountDownLatch latch2 = new CountDownLatch(1);
+			Disposable c = w.schedulePeriodically(() -> {
+				try {
+					latch.countDown();
+					latch2.await(10, TimeUnit.SECONDS);
+				}
+				catch (InterruptedException e) {
+				}
+			}, 10, 10, TimeUnit.MILLISECONDS);
+			Disposable d = c;
+			assertThat(d).isNotSameAs(Scheduler.REJECTED);
+
+			latch.await();
+			assertThat(d.isDisposed()).isFalse();
+			d.dispose();
+
+			Thread.yield();
+
+			latch2.countDown();
+
+			w.dispose();
+			assertThat(w.isDisposed()).isTrue();
+
+			c = w.schedule(() -> {
+			});
+
+			assertThat(c).isEqualTo(Scheduler.REJECTED);
+
+			d = c;
+			assertThat(d.isDisposed()).isTrue();
+			d.dispose();
+			assertThat(d.isDisposed()).isTrue();
+		}
+		finally {
+			w.dispose();
+			s.dispose();
+		}
+	}
+}

--- a/reactor-extra/src/test/java/reactor/scheduler/forkjoin/ForkJoinPoolSchedulerTest.java
+++ b/reactor-extra/src/test/java/reactor/scheduler/forkjoin/ForkJoinPoolSchedulerTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.scheduler.forkjoin;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ForkJoinPoolSchedulerTest extends AbstractSchedulerTest {
+
+	@Test(timeout = 500)
+	public void scheduleThenDisposeOfScheduler() throws Exception {
+		Scheduler s = ForkJoinPoolScheduler.create("test", 1);
+
+		CountDownLatch latch = new CountDownLatch(1);
+
+		s.schedule(latch::countDown, 50, TimeUnit.MILLISECONDS);
+
+		assertThat(s.isDisposed()).isFalse();
+		s.dispose();
+		assertThat(s.isDisposed()).isTrue();
+		assertThat(latch.await(100, TimeUnit.MILLISECONDS)).isFalse();
+	}
+
+	@Test(timeout = 500)
+	public void scheduleThenDisposeOfWorker() throws Exception {
+		Scheduler s = scheduler();
+
+		CountDownLatch latch = new CountDownLatch(1);
+
+		Scheduler.Worker worker = s.createWorker();
+
+		worker.schedule(latch::countDown, 50, TimeUnit.MILLISECONDS);
+
+		assertThat(worker.isDisposed()).isFalse();
+		worker.dispose();
+		assertThat(worker.isDisposed()).isTrue();
+		assertThat(latch.await(100, TimeUnit.MILLISECONDS)).isFalse();
+	}
+
+	@Test
+	public void scheduledDoesntReject() {
+		Scheduler s = scheduler();
+
+		assertThat(s.schedule(() -> {
+		}, 100, TimeUnit.MILLISECONDS)).describedAs("direct delayed scheduling")
+		                               .isNotSameAs(Scheduler.REJECTED);
+		assertThat(s.schedulePeriodically(() -> {
+		}, 100, 100, TimeUnit.MILLISECONDS)).describedAs("direct periodic scheduling")
+		                                    .isNotSameAs(Scheduler.REJECTED);
+
+		Scheduler.Worker w = s.createWorker();
+		assertThat(w.schedule(() -> {
+		}, 100, TimeUnit.MILLISECONDS)).describedAs("worker delayed scheduling")
+		                               .isNotSameAs(Scheduler.REJECTED);
+		assertThat(w.schedulePeriodically(() -> {
+		}, 100, 100, TimeUnit.MILLISECONDS)).describedAs("worker periodic scheduling")
+		                                    .isNotSameAs(Scheduler.REJECTED);
+	}
+
+	@Test
+	public void smokeTestDelay() {
+		for (int i = 0; i < 20; i++) {
+			Scheduler s = ForkJoinPoolScheduler.create("test");
+			AtomicLong start = new AtomicLong();
+			AtomicLong end = new AtomicLong();
+
+			try {
+				StepVerifier.create(Mono.delay(Duration.ofMillis(100), s)
+				                        .log()
+				                        .doOnSubscribe(sub -> start.set(System.nanoTime()))
+				                        .doOnTerminate((v, e) -> end.set(System.nanoTime())))
+				            .expectSubscription()
+				            .expectNext(0L)
+				            .verifyComplete();
+
+				long endValue = end.longValue();
+				long startValue = start.longValue();
+				long measuredDelay = endValue - startValue;
+				long measuredDelayMs = TimeUnit.NANOSECONDS.toMillis(measuredDelay);
+				assertThat(measuredDelayMs).as(
+						"iteration %s, measured delay %s nanos, start at %s nanos, end at %s nanos",
+						i,
+						measuredDelay,
+						startValue,
+						endValue)
+				                           .isGreaterThanOrEqualTo(100L)
+				                           .isLessThan(200L);
+			}
+			finally {
+				s.dispose();
+			}
+		}
+	}
+
+	@Test
+	public void smokeTestInterval() {
+		Scheduler s = scheduler();
+
+		try {
+			StepVerifier.create(Flux.interval(Duration.ofMillis(100),
+					Duration.ofMillis(200),
+					s))
+			            .expectSubscription()
+			            .expectNoEvent(Duration.ofMillis(100))
+			            .expectNext(0L)
+			            .expectNoEvent(Duration.ofMillis(200))
+			            .expectNext(1L)
+			            .expectNoEvent(Duration.ofMillis(200))
+			            .expectNext(2L)
+			            .thenCancel();
+		}
+		finally {
+			s.dispose();
+		}
+	}
+
+	@Override
+	protected Scheduler scheduler() {
+		return ForkJoinPoolScheduler.create("test");
+	}
+
+	@Override
+	protected boolean shouldCheckInterrupted() {
+		return true;
+	}
+
+}


### PR DESCRIPTION
this is a `Scheduler` implementation that uses a `ForkJoinPool` and peer
`Scheduler` for scheduling time-based tasks.

it differs from the Parallel scheduler in that Workers are not pre-bound
to a specific thread in the pool. each Worker maintains its own queue of
tasks and when it has tasks to execute it will grab a thread from the
pool to use to execute it.

since the ForkJoinPool does not support time-based scheduling, another
Scheduler is used to enqueue tasks in the main FJ pool as necessary.

i copied `AbstractSchedulerTest` since there does not appear to be an artifact for the tests from reactor-core