### PR TITLE
Tuple Decomposition Utilities

### DIFF
--- a/reactor-extra/src/main/java/reactor/function/Consumer3.java
+++ b/reactor-extra/src/main/java/reactor/function/Consumer3.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.function;
+
+/**
+ * An operation that accepts three input arguments and returns no result.
+ *
+ * @param <T1> The type of the first input to the operation
+ * @param <T2> The type of the second input to the operation
+ * @param <T3> The type of the third input to the operation
+ * @author Ben Hale
+ */
+@FunctionalInterface
+public interface Consumer3<T1, T2, T3> {
+
+    /**
+     * Performs this operation on the given arguments.
+     *
+     * @param t1 the first input argument
+     * @param t2 the second input argument
+     * @param t3 the third input argument
+     */
+    void accept(T1 t1, T2 t2, T3 t3);
+
+}

--- a/reactor-extra/src/main/java/reactor/function/Consumer4.java
+++ b/reactor-extra/src/main/java/reactor/function/Consumer4.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.function;
+
+/**
+ * An operation that accepts four input arguments and returns no result.
+ *
+ * @param <T1> The type of the first input to the operation
+ * @param <T2> The type of the second input to the operation
+ * @param <T3> The type of the third input to the operation
+ * @param <T4> The type of the fourth input to the operation
+ * @author Ben Hale
+ */
+@FunctionalInterface
+public interface Consumer4<T1, T2, T3, T4> {
+
+    /**
+     * Performs this operation on the given arguments.
+     *
+     * @param t1 the first input argument
+     * @param t2 the second input argument
+     * @param t3 the third input argument
+     * @param t4 the fourth input argument
+     */
+    void accept(T1 t1, T2 t2, T3 t3, T4 t4);
+
+}

--- a/reactor-extra/src/main/java/reactor/function/Consumer5.java
+++ b/reactor-extra/src/main/java/reactor/function/Consumer5.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.function;
+
+/**
+ * An operation that accepts five input arguments and returns no result.
+ *
+ * @param <T1> The type of the first input to the operation
+ * @param <T2> The type of the second input to the operation
+ * @param <T3> The type of the third input to the operation
+ * @param <T4> The type of the fourth input to the operation
+ * @param <T5> The type of the fifth input to the operation
+ * @author Ben Hale
+ */
+@FunctionalInterface
+public interface Consumer5<T1, T2, T3, T4, T5> {
+
+    /**
+     * Performs this operation on the given arguments.
+     *
+     * @param t1 the first input argument
+     * @param t2 the second input argument
+     * @param t3 the third input argument
+     * @param t4 the fourth input argument
+     * @param t5 the fifth input argument
+     */
+    void accept(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5);
+
+}

--- a/reactor-extra/src/main/java/reactor/function/Consumer6.java
+++ b/reactor-extra/src/main/java/reactor/function/Consumer6.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.function;
+
+/**
+ * An operation that accepts six input arguments and returns no result.
+ *
+ * @param <T1> The type of the first input to the operation
+ * @param <T2> The type of the second input to the operation
+ * @param <T3> The type of the third input to the operation
+ * @param <T4> The type of the fourth input to the operation
+ * @param <T5> The type of the fifth input to the operation
+ * @param <T6> The type of the sixth input to the operation
+ * @author Ben Hale
+ */
+@FunctionalInterface
+public interface Consumer6<T1, T2, T3, T4, T5, T6> {
+
+    /**
+     * Performs this operation on the given arguments.
+     *
+     * @param t1 the first input argument
+     * @param t2 the second input argument
+     * @param t3 the third input argument
+     * @param t4 the fourth input argument
+     * @param t5 the fifth input argument
+     * @param t6 the sixth input argument
+     */
+    void accept(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6);
+
+}

--- a/reactor-extra/src/main/java/reactor/function/Consumer7.java
+++ b/reactor-extra/src/main/java/reactor/function/Consumer7.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.function;
+
+/**
+ * An operation that accepts seven input arguments and returns no result.
+ *
+ * @param <T1> The type of the first input to the operation
+ * @param <T2> The type of the second input to the operation
+ * @param <T3> The type of the third input to the operation
+ * @param <T4> The type of the fourth input to the operation
+ * @param <T5> The type of the fifth input to the operation
+ * @param <T6> The type of the sixth input to the operation
+ * @param <T7> The type of the seventh input to the operation
+ * @author Ben Hale
+ */
+@FunctionalInterface
+public interface Consumer7<T1, T2, T3, T4, T5, T6, T7> {
+
+    /**
+     * Performs this operation on the given arguments.
+     *
+     * @param t1 the first input argument
+     * @param t2 the second input argument
+     * @param t3 the third input argument
+     * @param t4 the fourth input argument
+     * @param t5 the fifth input argument
+     * @param t6 the sixth input argument
+     * @param t7 the seventh input argument
+     */
+    void accept(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7);
+
+}

--- a/reactor-extra/src/main/java/reactor/function/Consumer8.java
+++ b/reactor-extra/src/main/java/reactor/function/Consumer8.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.function;
+
+/**
+ * An operation that accepts eight input arguments and returns no result.
+ *
+ * @param <T1> The type of the first input to the operation
+ * @param <T2> The type of the second input to the operation
+ * @param <T3> The type of the third input to the operation
+ * @param <T4> The type of the fourth input to the operation
+ * @param <T5> The type of the fifth input to the operation
+ * @param <T6> The type of the sixth input to the operation
+ * @param <T7> The type of the seventh input to the operation
+ * @param <T8> The type of the eighth input to the operation
+ * @author Ben Hale
+ */
+@FunctionalInterface
+public interface Consumer8<T1, T2, T3, T4, T5, T6, T7, T8> {
+
+    /**
+     * Performs this operation on the given arguments.
+     *
+     * @param t1 the first input argument
+     * @param t2 the second input argument
+     * @param t3 the third input argument
+     * @param t4 the fourth input argument
+     * @param t5 the fifth input argument
+     * @param t6 the sixth input argument
+     * @param t7 the seventh input argument
+     * @param t8 the eighth input argument
+     */
+    void accept(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8);
+
+}

--- a/reactor-extra/src/main/java/reactor/function/Function3.java
+++ b/reactor-extra/src/main/java/reactor/function/Function3.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.function;
+
+/**
+ * Represents a function that accepts three arguments and produces a result.
+ *
+ * @param <T1> The type of the first input to the function
+ * @param <T2> The type of the second input to the function
+ * @param <T3> The type of the third input to the function
+ * @param <R>  the type of the result of the function
+ * @author Ben Hale
+ */
+@FunctionalInterface
+public interface Function3<T1, T2, T3, R> {
+
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param t1 the first input argument
+     * @param t2 the second input argument
+     * @param t3 the third input argument
+     * @return the function result
+     */
+    R apply(T1 t1, T2 t2, T3 t3);
+
+}

--- a/reactor-extra/src/main/java/reactor/function/Function4.java
+++ b/reactor-extra/src/main/java/reactor/function/Function4.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.function;
+
+/**
+ * Represents a function that accepts four arguments and produces a result.
+ *
+ * @param <T1> The type of the first input to the function
+ * @param <T2> The type of the second input to the function
+ * @param <T3> The type of the third input to the function
+ * @param <T4> The type of the fourth input to the function
+ * @param <R>  the type of the result of the function
+ * @author Ben Hale
+ */
+@FunctionalInterface
+public interface Function4<T1, T2, T3, T4, R> {
+
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param t1 the first input argument
+     * @param t2 the second input argument
+     * @param t3 the third input argument
+     * @param t4 the fourth input argument
+     * @return the function result
+     */
+    R apply(T1 t1, T2 t2, T3 t3, T4 t4);
+
+}

--- a/reactor-extra/src/main/java/reactor/function/Function5.java
+++ b/reactor-extra/src/main/java/reactor/function/Function5.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.function;
+
+/**
+ * Represents a function that accepts five arguments and produces a result.
+ *
+ * @param <T1> The type of the first input to the function
+ * @param <T2> The type of the second input to the function
+ * @param <T3> The type of the third input to the function
+ * @param <T4> The type of the fourth input to the function
+ * @param <T5> The type of the fifth input to the function
+ * @param <R>  the type of the result of the function
+ * @author Ben Hale
+ */
+@FunctionalInterface
+public interface Function5<T1, T2, T3, T4, T5, R> {
+
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param t1 the first input argument
+     * @param t2 the second input argument
+     * @param t3 the third input argument
+     * @param t4 the fourth input argument
+     * @param t5 the fifth input argument
+     * @return the function result
+     */
+    R apply(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5);
+
+}

--- a/reactor-extra/src/main/java/reactor/function/Function6.java
+++ b/reactor-extra/src/main/java/reactor/function/Function6.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.function;
+
+/**
+ * Represents a function that accepts six arguments and produces a result.
+ *
+ * @param <T1> The type of the first input to the function
+ * @param <T2> The type of the second input to the function
+ * @param <T3> The type of the third input to the function
+ * @param <T4> The type of the fourth input to the function
+ * @param <T5> The type of the fifth input to the function
+ * @param <T6> The type of the sixth input to the function
+ * @param <R>  the type of the result of the function
+ * @author Ben Hale
+ */
+@FunctionalInterface
+public interface Function6<T1, T2, T3, T4, T5, T6, R> {
+
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param t1 the first input argument
+     * @param t2 the second input argument
+     * @param t3 the third input argument
+     * @param t4 the fourth input argument
+     * @param t5 the fifth input argument
+     * @param t6 the sixth input argument
+     * @return the function result
+     */
+    R apply(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6);
+
+}

--- a/reactor-extra/src/main/java/reactor/function/Function7.java
+++ b/reactor-extra/src/main/java/reactor/function/Function7.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.function;
+
+/**
+ * Represents a function that accepts seven arguments and produces a result.
+ *
+ * @param <T1> The type of the first input to the function
+ * @param <T2> The type of the second input to the function
+ * @param <T3> The type of the third input to the function
+ * @param <T4> The type of the fourth input to the function
+ * @param <T5> The type of the fifth input to the function
+ * @param <T6> The type of the sixth input to the function
+ * @param <T7> The type of the seventh input to the function
+ * @param <R>  the type of the result of the function
+ * @author Ben Hale
+ */
+@FunctionalInterface
+public interface Function7<T1, T2, T3, T4, T5, T6, T7, R> {
+
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param t1 the first input argument
+     * @param t2 the second input argument
+     * @param t3 the third input argument
+     * @param t4 the fourth input argument
+     * @param t5 the fifth input argument
+     * @param t6 the sixth input argument
+     * @param t7 the seventh input argument
+     * @return the function result
+     */
+    R apply(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7);
+
+}

--- a/reactor-extra/src/main/java/reactor/function/Function8.java
+++ b/reactor-extra/src/main/java/reactor/function/Function8.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.function;
+
+/**
+ * Represents a function that accepts eight arguments and produces a result.
+ *
+ * @param <T1> The type of the first input to the function
+ * @param <T2> The type of the second input to the function
+ * @param <T3> The type of the third input to the function
+ * @param <T4> The type of the fourth input to the function
+ * @param <T5> The type of the fifth input to the function
+ * @param <T6> The type of the sixth input to the function
+ * @param <T7> The type of the seventh input to the function
+ * @param <T8> The type of the eighth input to the function
+ * @param <R>  the type of the result of the function
+ * @author Ben Hale
+ */
+@FunctionalInterface
+public interface Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> {
+
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param t1 the first input argument
+     * @param t2 the second input argument
+     * @param t3 the third input argument
+     * @param t4 the fourth input argument
+     * @param t5 the fifth input argument
+     * @param t6 the sixth input argument
+     * @param t7 the seventh input argument
+     * @param t8 the eighth input argument
+     * @return the function result
+     */
+    R apply(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8);
+
+}

--- a/reactor-extra/src/main/java/reactor/function/Predicate3.java
+++ b/reactor-extra/src/main/java/reactor/function/Predicate3.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.function;
+
+/**
+ * Represents a predicate (boolean-valued function) of three arguments.
+ *
+ * @param <T1> The type of the first input to the predicate
+ * @param <T2> The type of the second input to the predicate
+ * @param <T3> The type of the third input to the predicate
+ * @author Ben Hale
+ */
+@FunctionalInterface
+public interface Predicate3<T1, T2, T3> {
+
+    /**
+     * Evaluates this predicate on the given arguments.
+     *
+     * @param t1 the first input argument
+     * @param t2 the second input argument
+     * @param t3 the third input argument
+     * @return {@code true} if the input arguments match the predicate, otherwise {@code false}
+     */
+    boolean test(T1 t1, T2 t2, T3 t3);
+
+}

--- a/reactor-extra/src/main/java/reactor/function/Predicate4.java
+++ b/reactor-extra/src/main/java/reactor/function/Predicate4.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.function;
+
+/**
+ * Represents a predicate (boolean-valued function) of four arguments.
+ *
+ * @param <T1> The type of the first input to the predicate
+ * @param <T2> The type of the second input to the predicate
+ * @param <T3> The type of the third input to the predicate
+ * @param <T4> The type of the fourth input to the predicate
+ * @author Ben Hale
+ */
+@FunctionalInterface
+public interface Predicate4<T1, T2, T3, T4> {
+
+    /**
+     * Evaluates this predicate on the given arguments.
+     *
+     * @param t1 the first input argument
+     * @param t2 the second input argument
+     * @param t3 the third input argument
+     * @param t4 the fourth input argument
+     * @return {@code true} if the input arguments match the predicate, otherwise {@code false}
+     */
+    boolean test(T1 t1, T2 t2, T3 t3, T4 t4);
+
+}

--- a/reactor-extra/src/main/java/reactor/function/Predicate5.java
+++ b/reactor-extra/src/main/java/reactor/function/Predicate5.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.function;
+
+/**
+ * Represents a predicate (boolean-valued function) of five arguments.
+ *
+ * @param <T1> The type of the first input to the predicate
+ * @param <T2> The type of the second input to the predicate
+ * @param <T3> The type of the third input to the predicate
+ * @param <T4> The type of the fourth input to the predicate
+ * @param <T5> The type of the fifth input to the predicate
+ * @author Ben Hale
+ */
+@FunctionalInterface
+public interface Predicate5<T1, T2, T3, T4, T5> {
+
+    /**
+     * Evaluates this predicate on the given arguments.
+     *
+     * @param t1 the first input argument
+     * @param t2 the second input argument
+     * @param t3 the third input argument
+     * @param t4 the fourth input argument
+     * @param t5 the fifth input argument
+     * @return {@code true} if the input arguments match the predicate, otherwise {@code false}
+     */
+    boolean test(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5);
+
+}

--- a/reactor-extra/src/main/java/reactor/function/Predicate6.java
+++ b/reactor-extra/src/main/java/reactor/function/Predicate6.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.function;
+
+/**
+ * Represents a predicate (boolean-valued function) of six arguments.
+ *
+ * @param <T1> The type of the first input to the predicate
+ * @param <T2> The type of the second input to the predicate
+ * @param <T3> The type of the third input to the predicate
+ * @param <T4> The type of the fourth input to the predicate
+ * @param <T5> The type of the fifth input to the predicate
+ * @param <T6> The type of the sixth input to the predicate
+ * @author Ben Hale
+ */
+@FunctionalInterface
+public interface Predicate6<T1, T2, T3, T4, T5, T6> {
+
+    /**
+     * Evaluates this predicate on the given arguments.
+     *
+     * @param t1 the first input argument
+     * @param t2 the second input argument
+     * @param t3 the third input argument
+     * @param t4 the fourth input argument
+     * @param t5 the fifth input argument
+     * @param t6 the sixth input argument
+     * @return {@code true} if the input arguments match the predicate, otherwise {@code false}
+     */
+    boolean test(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6);
+
+}

--- a/reactor-extra/src/main/java/reactor/function/Predicate7.java
+++ b/reactor-extra/src/main/java/reactor/function/Predicate7.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.function;
+
+/**
+ * Represents a predicate (boolean-valued function) of seven arguments.
+ *
+ * @param <T1> The type of the first input to the predicate
+ * @param <T2> The type of the second input to the predicate
+ * @param <T3> The type of the third input to the predicate
+ * @param <T4> The type of the fourth input to the predicate
+ * @param <T5> The type of the fifth input to the predicate
+ * @param <T6> The type of the sixth input to the predicate
+ * @param <T7> The type of the seventh input to the predicate
+ * @author Ben Hale
+ */
+@FunctionalInterface
+public interface Predicate7<T1, T2, T3, T4, T5, T6, T7> {
+
+    /**
+     * Evaluates this predicate on the given arguments.
+     *
+     * @param t1 the first input argument
+     * @param t2 the second input argument
+     * @param t3 the third input argument
+     * @param t4 the fourth input argument
+     * @param t5 the fifth input argument
+     * @param t6 the sixth input argument
+     * @param t7 the seventh input argument
+     * @return {@code true} if the input arguments match the predicate, otherwise {@code false}
+     */
+    boolean test(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7);
+
+}

--- a/reactor-extra/src/main/java/reactor/function/Predicate8.java
+++ b/reactor-extra/src/main/java/reactor/function/Predicate8.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.function;
+
+/**
+ * Represents a predicate (boolean-valued function) of eight arguments.
+ *
+ * @param <T1> The type of the first input to the predicate
+ * @param <T2> The type of the second input to the predicate
+ * @param <T3> The type of the third input to the predicate
+ * @param <T4> The type of the fourth input to the predicate
+ * @param <T5> The type of the fifth input to the predicate
+ * @param <T6> The type of the sixth input to the predicate
+ * @param <T7> The type of the seventh input to the predicate
+ * @param <T8> The type of the eighth input to the predicate
+ * @author Ben Hale
+ */
+@FunctionalInterface
+public interface Predicate8<T1, T2, T3, T4, T5, T6, T7, T8> {
+
+    /**
+     * Evaluates this predicate on the given arguments.
+     *
+     * @param t1 the first input argument
+     * @param t2 the second input argument
+     * @param t3 the third input argument
+     * @param t4 the fourth input argument
+     * @param t5 the fifth input argument
+     * @param t6 the sixth input argument
+     * @param t7 the seventh input argument
+     * @param t8 the eighth input argument
+     * @return {@code true} if the input arguments match the predicate, otherwise {@code false}
+     */
+    boolean test(T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8);
+
+}

--- a/reactor-extra/src/main/java/reactor/function/TupleUtils.java
+++ b/reactor-extra/src/main/java/reactor/function/TupleUtils.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.function;
+
+import reactor.util.function.*;
+
+import java.util.function.*;
+
+public final class TupleUtils {
+
+    private TupleUtils() {
+    }
+
+    /**
+     * Returns a {@link Consumer} of {@link Tuple2} that wraps a consumer of the component values of the tuple
+     *
+     * @param consumer the component value consumer
+     * @param <T1>     the type of the first value
+     * @param <T2>     the type of the second value
+     * @return the wrapper consumer
+     */
+    public static <T1, T2> Consumer<Tuple2<T1, T2>> consumer(BiConsumer<T1, T2> consumer) {
+        return tuple -> consumer.accept(tuple.getT1(), tuple.getT2());
+    }
+
+    /**
+     * Returns a {@link Consumer} of {@link Tuple3} that wraps a consumer of the component values of the tuple
+     *
+     * @param consumer the component value consumer
+     * @param <T1>     the type of the first value
+     * @param <T2>     the type of the second value
+     * @param <T3>     the type of the third value
+     * @return the wrapper consumer
+     */
+    public static <T1, T2, T3> Consumer<Tuple3<T1, T2, T3>> consumer(Consumer3<T1, T2, T3> consumer) {
+        return tuple -> consumer.accept(tuple.getT1(), tuple.getT2(), tuple.getT3());
+    }
+
+    /**
+     * Returns a {@link Consumer} of {@link Tuple4} that wraps a consumer of the component values of the tuple
+     *
+     * @param consumer the component value consumer
+     * @param <T1>     the type of the first value
+     * @param <T2>     the type of the second value
+     * @param <T3>     the type of the third value
+     * @param <T4>     the type of the fourth value
+     * @return the wrapper consumer
+     */
+    public static <T1, T2, T3, T4> Consumer<Tuple4<T1, T2, T3, T4>> consumer(Consumer4<T1, T2, T3, T4> consumer) {
+        return tuple -> consumer.accept(tuple.getT1(), tuple.getT2(), tuple.getT3(), tuple.getT4());
+    }
+
+    /**
+     * Returns a {@link Consumer} of {@link Tuple5} that wraps a consumer of the component values of the tuple
+     *
+     * @param consumer the component value consumer
+     * @param <T1>     the type of the first value
+     * @param <T2>     the type of the second value
+     * @param <T3>     the type of the third value
+     * @param <T4>     the type of the fourth value
+     * @param <T5>     the type of the fifth value
+     * @return the wrapper consumer
+     */
+    public static <T1, T2, T3, T4, T5> Consumer<Tuple5<T1, T2, T3, T4, T5>> consumer(Consumer5<T1, T2, T3, T4, T5> consumer) {
+        return tuple -> consumer.accept(tuple.getT1(), tuple.getT2(), tuple.getT3(), tuple.getT4(), tuple.getT5());
+    }
+
+    /**
+     * Returns a {@link Consumer} of {@link Tuple6} that wraps a consumer of the component values of the tuple
+     *
+     * @param consumer the component value consumer
+     * @param <T1>     the type of the first value
+     * @param <T2>     the type of the second value
+     * @param <T3>     the type of the third value
+     * @param <T4>     the type of the fourth value
+     * @param <T5>     the type of the fifth value
+     * @param <T6>     the type of the sixth value
+     * @return the wrapper consumer
+     */
+    public static <T1, T2, T3, T4, T5, T6> Consumer<Tuple6<T1, T2, T3, T4, T5, T6>> consumer(Consumer6<T1, T2, T3, T4, T5, T6> consumer) {
+        return tuple -> consumer.accept(tuple.getT1(), tuple.getT2(), tuple.getT3(), tuple.getT4(), tuple.getT5(), tuple.getT6());
+    }
+
+    /**
+     * Returns a {@link Consumer} of {@link Tuple7} that wraps a consumer of the component values of the tuple
+     *
+     * @param consumer the component value consumer
+     * @param <T1>     the type of the first value
+     * @param <T2>     the type of the second value
+     * @param <T3>     the type of the third value
+     * @param <T4>     the type of the fourth value
+     * @param <T5>     the type of the fifth value
+     * @param <T6>     the type of the sixth value
+     * @param <T7>     the type of the seventh value
+     * @return the wrapper consumer
+     */
+    public static <T1, T2, T3, T4, T5, T6, T7> Consumer<Tuple7<T1, T2, T3, T4, T5, T6, T7>> consumer(Consumer7<T1, T2, T3, T4, T5, T6, T7> consumer) {
+        return tuple -> consumer.accept(tuple.getT1(), tuple.getT2(), tuple.getT3(), tuple.getT4(), tuple.getT5(), tuple.getT6(), tuple.getT7());
+    }
+
+    /**
+     * Returns a {@link Consumer} of {@link Tuple8} that wraps a consumer of the component values of the tuple
+     *
+     * @param consumer the component value consumer
+     * @param <T1>     the type of the first value
+     * @param <T2>     the type of the second value
+     * @param <T3>     the type of the third value
+     * @param <T4>     the type of the fourth value
+     * @param <T5>     the type of the fifth value
+     * @param <T6>     the type of the sixth value
+     * @param <T7>     the type of the seventh value
+     * @param <T8>     the type of the eighth value
+     * @return the wrapper consumer
+     */
+    public static <T1, T2, T3, T4, T5, T6, T7, T8> Consumer<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>> consumer(Consumer8<T1, T2, T3, T4, T5, T6, T7, T8> consumer) {
+        return tuple -> consumer.accept(tuple.getT1(), tuple.getT2(), tuple.getT3(), tuple.getT4(), tuple.getT5(), tuple.getT6(), tuple.getT7(), tuple.getT8());
+    }
+
+    /**
+     * Returns a {@link Function} of {@link Tuple2} that wraps a function of the component values of the tuple
+     *
+     * @param function the component value function
+     * @param <T1>     the type of the first value
+     * @param <T2>     the type of the second value
+     * @param <R>      the type of the result of the function
+     * @return the wrapper function
+     */
+    public static <T1, T2, R> Function<Tuple2<T1, T2>, R> function(BiFunction<T1, T2, R> function) {
+        return tuple -> function.apply(tuple.getT1(), tuple.getT2());
+    }
+
+    /**
+     * Returns a {@link Function} of {@link Tuple3} that wraps a function of the component values of the tuple
+     *
+     * @param function the component value function
+     * @param <T1>     the type of the first value
+     * @param <T2>     the type of the second value
+     * @param <T3>     the type of the third value
+     * @param <R>      the type of the result of the function
+     * @return the wrapper function
+     */
+    public static <T1, T2, T3, R> Function<Tuple3<T1, T2, T3>, R> function(Function3<T1, T2, T3, R> function) {
+        return tuple -> function.apply(tuple.getT1(), tuple.getT2(), tuple.getT3());
+    }
+
+    /**
+     * Returns a {@link Function} of {@link Tuple4} that wraps a function of the component values of the tuple
+     *
+     * @param function the component value function
+     * @param <T1>     the type of the first value
+     * @param <T2>     the type of the second value
+     * @param <T3>     the type of the third value
+     * @param <T4>     the type of the fourth value
+     * @param <R>      the type of the result of the function
+     * @return the wrapper function
+     */
+    public static <T1, T2, T3, T4, R> Function<Tuple4<T1, T2, T3, T4>, R> function(Function4<T1, T2, T3, T4, R> function) {
+        return tuple -> function.apply(tuple.getT1(), tuple.getT2(), tuple.getT3(), tuple.getT4());
+    }
+
+    /**
+     * Returns a {@link Function} of {@link Tuple5} that wraps a function of the component values of the tuple
+     *
+     * @param function the component value function
+     * @param <T1>     the type of the first value
+     * @param <T2>     the type of the second value
+     * @param <T3>     the type of the third value
+     * @param <T4>     the type of the fourth value
+     * @param <T5>     the type of the fifth value
+     * @param <R>      the type of the result of the function
+     * @return the wrapper function
+     */
+    public static <T1, T2, T3, T4, T5, R> Function<Tuple5<T1, T2, T3, T4, T5>, R> function(Function5<T1, T2, T3, T4, T5, R> function) {
+        return tuple -> function.apply(tuple.getT1(), tuple.getT2(), tuple.getT3(), tuple.getT4(), tuple.getT5());
+    }
+
+    /**
+     * Returns a {@link Function} of {@link Tuple6} that wraps a function of the component values of the tuple
+     *
+     * @param function the component value function
+     * @param <T1>     the type of the first value
+     * @param <T2>     the type of the second value
+     * @param <T3>     the type of the third value
+     * @param <T4>     the type of the fourth value
+     * @param <T5>     the type of the fifth value
+     * @param <T6>     the type of the sixth value
+     * @param <R>      the type of the result of the function
+     * @return the wrapper function
+     */
+    public static <T1, T2, T3, T4, T5, T6, R> Function<Tuple6<T1, T2, T3, T4, T5, T6>, R> function(Function6<T1, T2, T3, T4, T5, T6, R> function) {
+        return tuple -> function.apply(tuple.getT1(), tuple.getT2(), tuple.getT3(), tuple.getT4(), tuple.getT5(), tuple.getT6());
+    }
+
+    /**
+     * Returns a {@link Function} of {@link Tuple7} that wraps a function of the component values of the tuple
+     *
+     * @param function the component value function
+     * @param <T1>     the type of the first value
+     * @param <T2>     the type of the second value
+     * @param <T3>     the type of the third value
+     * @param <T4>     the type of the fourth value
+     * @param <T5>     the type of the fifth value
+     * @param <T6>     the type of the sixth value
+     * @param <T7>     the type of the seventh value
+     * @param <R>      the type of the result of the function
+     * @return the wrapper function
+     */
+    public static <T1, T2, T3, T4, T5, T6, T7, R> Function<Tuple7<T1, T2, T3, T4, T5, T6, T7>, R> function(Function7<T1, T2, T3, T4, T5, T6, T7, R> function) {
+        return tuple -> function.apply(tuple.getT1(), tuple.getT2(), tuple.getT3(), tuple.getT4(), tuple.getT5(), tuple.getT6(), tuple.getT7());
+    }
+
+    /**
+     * Returns a {@link Function} of {@link Tuple8} that wraps a function of the component values of the tuple
+     *
+     * @param function the component value function
+     * @param <T1>     the type of the first value
+     * @param <T2>     the type of the second value
+     * @param <T3>     the type of the third value
+     * @param <T4>     the type of the fourth value
+     * @param <T5>     the type of the fifth value
+     * @param <T6>     the type of the sixth value
+     * @param <T7>     the type of the seventh value
+     * @param <T8>     the type of the eighth value
+     * @param <R>      the type of the result of the function
+     * @return the wrapper function
+     */
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, R> Function<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>, R> function(Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> function) {
+        return tuple -> function.apply(tuple.getT1(), tuple.getT2(), tuple.getT3(), tuple.getT4(), tuple.getT5(), tuple.getT6(), tuple.getT7(), tuple.getT8());
+    }
+
+    /**
+     * Returns a {@link Predicate} of {@link Tuple2} that wraps a predicate of the component values of the tuple
+     *
+     * @param predicate the component value predicate
+     * @param <T1>      the type of the first value
+     * @param <T2>      the type of the second value
+     * @return the wrapper predicate
+     */
+    public static <T1, T2> Predicate<Tuple2<T1, T2>> predicate(BiPredicate<T1, T2> predicate) {
+        return tuple -> predicate.test(tuple.getT1(), tuple.getT2());
+    }
+
+    /**
+     * Returns a {@link Predicate} of {@link Tuple3} that wraps a predicate of the component values of the tuple
+     *
+     * @param predicate the component value predicate
+     * @param <T1>      the type of the first value
+     * @param <T2>      the type of the second value
+     * @param <T3>      the type of the third value
+     * @return the wrapper predicate
+     */
+    public static <T1, T2, T3> Predicate<Tuple3<T1, T2, T3>> predicate(Predicate3<T1, T2, T3> predicate) {
+        return tuple -> predicate.test(tuple.getT1(), tuple.getT2(), tuple.getT3());
+    }
+
+    /**
+     * Returns a {@link Predicate} of {@link Tuple4} that wraps a predicate of the component values of the tuple
+     *
+     * @param predicate the component value predicate
+     * @param <T1>      the type of the first value
+     * @param <T2>      the type of the second value
+     * @param <T3>      the type of the third value
+     * @param <T4>      the type of the fourth value
+     * @return the wrapper predicate
+     */
+    public static <T1, T2, T3, T4> Predicate<Tuple4<T1, T2, T3, T4>> predicate(Predicate4<T1, T2, T3, T4> predicate) {
+        return tuple -> predicate.test(tuple.getT1(), tuple.getT2(), tuple.getT3(), tuple.getT4());
+    }
+
+    /**
+     * Returns a {@link Predicate} of {@link Tuple5} that wraps a predicate of the component values of the tuple
+     *
+     * @param predicate the component value predicate
+     * @param <T1>      the type of the first value
+     * @param <T2>      the type of the second value
+     * @param <T3>      the type of the third value
+     * @param <T4>      the type of the fourth value
+     * @param <T5>      the type of the fifth value
+     * @return the wrapper predicate
+     */
+    public static <T1, T2, T3, T4, T5> Predicate<Tuple5<T1, T2, T3, T4, T5>> predicate(Predicate5<T1, T2, T3, T4, T5> predicate) {
+        return tuple -> predicate.test(tuple.getT1(), tuple.getT2(), tuple.getT3(), tuple.getT4(), tuple.getT5());
+    }
+
+    /**
+     * Returns a {@link Predicate} of {@link Tuple6} that wraps a predicate of the component values of the tuple
+     *
+     * @param predicate the component value predicate
+     * @param <T1>      the type of the first value
+     * @param <T2>      the type of the second value
+     * @param <T3>      the type of the third value
+     * @param <T4>      the type of the fourth value
+     * @param <T5>      the type of the fifth value
+     * @param <T6>      the type of the sixth value
+     * @return the wrapper predicate
+     */
+    public static <T1, T2, T3, T4, T5, T6> Predicate<Tuple6<T1, T2, T3, T4, T5, T6>> predicate(Predicate6<T1, T2, T3, T4, T5, T6> predicate) {
+        return tuple -> predicate.test(tuple.getT1(), tuple.getT2(), tuple.getT3(), tuple.getT4(), tuple.getT5(), tuple.getT6());
+    }
+
+    /**
+     * Returns a {@link Predicate} of {@link Tuple7} that wraps a predicate of the component values of the tuple
+     *
+     * @param predicate the component value predicate
+     * @param <T1>      the type of the first value
+     * @param <T2>      the type of the second value
+     * @param <T3>      the type of the third value
+     * @param <T4>      the type of the fourth value
+     * @param <T5>      the type of the fifth value
+     * @param <T6>      the type of the sixth value
+     * @param <T7>      the type of the seventh value
+     * @return the wrapper predicate
+     */
+    public static <T1, T2, T3, T4, T5, T6, T7> Predicate<Tuple7<T1, T2, T3, T4, T5, T6, T7>> predicate(Predicate7<T1, T2, T3, T4, T5, T6, T7> predicate) {
+        return tuple -> predicate.test(tuple.getT1(), tuple.getT2(), tuple.getT3(), tuple.getT4(), tuple.getT5(), tuple.getT6(), tuple.getT7());
+    }
+
+    /**
+     * Returns a {@link Predicate} of {@link Tuple8} that wraps a predicate of the component values of the tuple
+     *
+     * @param predicate the component value predicate
+     * @param <T1>      the type of the first value
+     * @param <T2>      the type of the second value
+     * @param <T3>      the type of the third value
+     * @param <T4>      the type of the fourth value
+     * @param <T5>      the type of the fifth value
+     * @param <T6>      the type of the sixth value
+     * @param <T7>      the type of the seventh value
+     * @param <T8>      the type of the eighth value
+     * @return the wrapper predicate
+     */
+    public static <T1, T2, T3, T4, T5, T6, T7, T8> Predicate<Tuple8<T1, T2, T3, T4, T5, T6, T7, T8>> predicate(Predicate8<T1, T2, T3, T4, T5, T6, T7, T8> predicate) {
+        return tuple -> predicate.test(tuple.getT1(), tuple.getT2(), tuple.getT3(), tuple.getT4(), tuple.getT5(), tuple.getT6(), tuple.getT7(), tuple.getT8());
+    }
+
+}

--- a/reactor-extra/src/test/java/reactor/function/TupleUtilsTest.java
+++ b/reactor-extra/src/test/java/reactor/function/TupleUtilsTest.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.function;
+
+import org.junit.Test;
+import reactor.util.function.Tuples;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class TupleUtilsTest {
+
+    @Test
+    public void consumer2() {
+        TupleUtils
+            .consumer((first, second) -> {
+                assertThat(first).isEqualTo(1);
+                assertThat(second).isEqualTo(2);
+            })
+            .accept(Tuples.of(1, 2));
+    }
+
+    @Test
+    public void consumer3() {
+        TupleUtils
+            .consumer((first, second, third) -> {
+                assertThat(first).isEqualTo(1);
+                assertThat(second).isEqualTo(2);
+                assertThat(third).isEqualTo(3);
+            })
+            .accept(Tuples.of(1, 2, 3));
+    }
+
+    @Test
+    public void consumer4() {
+        TupleUtils
+            .consumer((first, second, third, fourth) -> {
+                assertThat(first).isEqualTo(1);
+                assertThat(second).isEqualTo(2);
+                assertThat(third).isEqualTo(3);
+                assertThat(fourth).isEqualTo(4);
+            })
+            .accept(Tuples.of(1, 2, 3, 4));
+    }
+
+    @Test
+    public void consumer5() {
+        TupleUtils
+            .consumer((first, second, third, fourth, fifth) -> {
+                assertThat(first).isEqualTo(1);
+                assertThat(second).isEqualTo(2);
+                assertThat(third).isEqualTo(3);
+                assertThat(fourth).isEqualTo(4);
+                assertThat(fifth).isEqualTo(5);
+            })
+            .accept(Tuples.of(1, 2, 3, 4, 5));
+    }
+
+    @Test
+    public void consumer6() {
+        TupleUtils
+            .consumer((first, second, third, fourth, fifth, sixth) -> {
+                assertThat(first).isEqualTo(1);
+                assertThat(second).isEqualTo(2);
+                assertThat(third).isEqualTo(3);
+                assertThat(fourth).isEqualTo(4);
+                assertThat(fifth).isEqualTo(5);
+                assertThat(sixth).isEqualTo(6);
+            })
+            .accept(Tuples.of(1, 2, 3, 4, 5, 6));
+    }
+
+    @Test
+    public void consumer7() {
+        TupleUtils
+            .consumer((first, second, third, fourth, fifth, sixth, seventh) -> {
+                assertThat(first).isEqualTo(1);
+                assertThat(second).isEqualTo(2);
+                assertThat(third).isEqualTo(3);
+                assertThat(fourth).isEqualTo(4);
+                assertThat(fifth).isEqualTo(5);
+                assertThat(sixth).isEqualTo(6);
+                assertThat(seventh).isEqualTo(7);
+            })
+            .accept(Tuples.of(1, 2, 3, 4, 5, 6, 7));
+    }
+
+    @Test
+    public void consumer8() {
+        TupleUtils
+            .consumer((first, second, third, fourth, fifth, sixth, seventh, eighth) -> {
+                assertThat(first).isEqualTo(1);
+                assertThat(second).isEqualTo(2);
+                assertThat(third).isEqualTo(3);
+                assertThat(fourth).isEqualTo(4);
+                assertThat(fifth).isEqualTo(5);
+                assertThat(sixth).isEqualTo(6);
+                assertThat(seventh).isEqualTo(7);
+                assertThat(eighth).isEqualTo(8);
+            })
+            .accept(Tuples.of(1, 2, 3, 4, 5, 6, 7, 8));
+    }
+
+    @Test
+    public void function2() {
+        int result = TupleUtils
+            .function((first, second) -> {
+                assertThat(first).isEqualTo(1);
+                assertThat(second).isEqualTo(2);
+
+                return -1;
+            })
+            .apply(Tuples.of(1, 2));
+
+        assertThat(result).isEqualTo(-1);
+    }
+
+    @Test
+    public void function3() {
+        int result = TupleUtils
+            .function((first, second, third) -> {
+                assertThat(first).isEqualTo(1);
+                assertThat(second).isEqualTo(2);
+                assertThat(third).isEqualTo(3);
+
+                return -1;
+            })
+            .apply(Tuples.of(1, 2, 3));
+
+        assertThat(result).isEqualTo(-1);
+    }
+
+    @Test
+    public void function4() {
+        int result = TupleUtils
+            .function((first, second, third, fourth) -> {
+                assertThat(first).isEqualTo(1);
+                assertThat(second).isEqualTo(2);
+                assertThat(third).isEqualTo(3);
+                assertThat(fourth).isEqualTo(4);
+
+                return -1;
+            })
+            .apply(Tuples.of(1, 2, 3, 4));
+
+        assertThat(result).isEqualTo(-1);
+    }
+
+    @Test
+    public void function5() {
+        int result = TupleUtils
+            .function((first, second, third, fourth, fifth) -> {
+                assertThat(first).isEqualTo(1);
+                assertThat(second).isEqualTo(2);
+                assertThat(third).isEqualTo(3);
+                assertThat(fourth).isEqualTo(4);
+                assertThat(fifth).isEqualTo(5);
+
+                return -1;
+            })
+            .apply(Tuples.of(1, 2, 3, 4, 5));
+
+        assertThat(result).isEqualTo(-1);
+    }
+
+    @Test
+    public void function6() {
+        int result = TupleUtils
+            .function((first, second, third, fourth, fifth, sixth) -> {
+                assertThat(first).isEqualTo(1);
+                assertThat(second).isEqualTo(2);
+                assertThat(third).isEqualTo(3);
+                assertThat(fourth).isEqualTo(4);
+                assertThat(fifth).isEqualTo(5);
+                assertThat(sixth).isEqualTo(6);
+
+                return -1;
+            })
+            .apply(Tuples.of(1, 2, 3, 4, 5, 6));
+
+        assertThat(result).isEqualTo(-1);
+    }
+
+    @Test
+    public void function7() {
+        int result = TupleUtils
+            .function((first, second, third, fourth, fifth, sixth, seventh) -> {
+                assertThat(first).isEqualTo(1);
+                assertThat(second).isEqualTo(2);
+                assertThat(third).isEqualTo(3);
+                assertThat(fourth).isEqualTo(4);
+                assertThat(fifth).isEqualTo(5);
+                assertThat(sixth).isEqualTo(6);
+                assertThat(seventh).isEqualTo(7);
+
+                return -1;
+            })
+            .apply(Tuples.of(1, 2, 3, 4, 5, 6, 7));
+
+        assertThat(result).isEqualTo(-1);
+    }
+
+    @Test
+    public void function8() {
+        int result = TupleUtils
+            .function((first, second, third, fourth, fifth, sixth, seventh, eighth) -> {
+                assertThat(first).isEqualTo(1);
+                assertThat(second).isEqualTo(2);
+                assertThat(third).isEqualTo(3);
+                assertThat(fourth).isEqualTo(4);
+                assertThat(fifth).isEqualTo(5);
+                assertThat(sixth).isEqualTo(6);
+                assertThat(seventh).isEqualTo(7);
+                assertThat(eighth).isEqualTo(8);
+
+                return -1;
+            })
+            .apply(Tuples.of(1, 2, 3, 4, 5, 6, 7, 8));
+
+        assertThat(result).isEqualTo(-1);
+    }
+
+    @Test
+    public void predicate2() {
+        boolean result = TupleUtils
+            .predicate((first, second) -> {
+                assertThat(first).isEqualTo(1);
+                assertThat(second).isEqualTo(2);
+
+                return true;
+            })
+            .test(Tuples.of(1, 2));
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void predicate3() {
+        boolean result = TupleUtils
+            .predicate((first, second, third) -> {
+                assertThat(first).isEqualTo(1);
+                assertThat(second).isEqualTo(2);
+                assertThat(third).isEqualTo(3);
+
+                return true;
+            })
+            .test(Tuples.of(1, 2, 3));
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void predicate4() {
+        boolean result = TupleUtils
+            .predicate((first, second, third, fourth) -> {
+                assertThat(first).isEqualTo(1);
+                assertThat(second).isEqualTo(2);
+                assertThat(third).isEqualTo(3);
+                assertThat(fourth).isEqualTo(4);
+
+                return true;
+            })
+            .test(Tuples.of(1, 2, 3, 4));
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void predicate5() {
+        boolean result = TupleUtils
+            .predicate((first, second, third, fourth, fifth) -> {
+                assertThat(first).isEqualTo(1);
+                assertThat(second).isEqualTo(2);
+                assertThat(third).isEqualTo(3);
+                assertThat(fourth).isEqualTo(4);
+                assertThat(fifth).isEqualTo(5);
+
+                return true;
+            })
+            .test(Tuples.of(1, 2, 3, 4, 5));
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void predicate6() {
+        boolean result = TupleUtils
+            .predicate((first, second, third, fourth, fifth, sixth) -> {
+                assertThat(first).isEqualTo(1);
+                assertThat(second).isEqualTo(2);
+                assertThat(third).isEqualTo(3);
+                assertThat(fourth).isEqualTo(4);
+                assertThat(fifth).isEqualTo(5);
+                assertThat(sixth).isEqualTo(6);
+
+                return true;
+            })
+            .test(Tuples.of(1, 2, 3, 4, 5, 6));
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void predicate7() {
+        boolean result = TupleUtils
+            .predicate((first, second, third, fourth, fifth, sixth, seventh) -> {
+                assertThat(first).isEqualTo(1);
+                assertThat(second).isEqualTo(2);
+                assertThat(third).isEqualTo(3);
+                assertThat(fourth).isEqualTo(4);
+                assertThat(fifth).isEqualTo(5);
+                assertThat(sixth).isEqualTo(6);
+                assertThat(seventh).isEqualTo(7);
+
+                return true;
+            })
+            .test(Tuples.of(1, 2, 3, 4, 5, 6, 7));
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void predicate8() {
+        boolean result = TupleUtils
+            .predicate((first, second, third, fourth, fifth, sixth, seventh, eighth) -> {
+                assertThat(first).isEqualTo(1);
+                assertThat(second).isEqualTo(2);
+                assertThat(third).isEqualTo(3);
+                assertThat(fourth).isEqualTo(4);
+                assertThat(fifth).isEqualTo(5);
+                assertThat(sixth).isEqualTo(6);
+                assertThat(seventh).isEqualTo(7);
+                assertThat(eighth).isEqualTo(8);
+
+                return true;
+            })
+            .test(Tuples.of(1, 2, 3, 4, 5, 6, 7, 8));
+
+        assertThat(result).isTrue();
+    }
+
+}


### PR DESCRIPTION
This change contributes a set of static methods that transform `Consumer`s, `Function`s, and `Predicate`s of `TupleN` into `Consumer`s, `Function`s, and `Predicate`s of N values, called with the contents of a `Tuple`.  This allows a function written like this

```java
.map(tuple -> {
  String name = tuple.getT1();
  String street = tuple.getT2();
  String city = tuple.getT3();
  String state = tuple.getT4();
  String zipcode = tuple.getT5();

  return String.format(...);
})
```

to instead be written as

```java
.map(function((name, street, city, state, zipcode) -> String.format(...)))
```

and the equivalent for `Consumer`s and `Predicate`s.  These utility functions make closures dealing with `Tuple`s more expressive and less verbose.