### PR TITLE
Adapt to latest changes in core Operators and Mono.doOnTerminate

### DIFF
--- a/reactor-adapter/src/main/java/reactor/adapter/akka/ActorScheduler.java
+++ b/reactor-adapter/src/main/java/reactor/adapter/akka/ActorScheduler.java
@@ -27,6 +27,7 @@ import akka.actor.UntypedActor;
 import reactor.core.Disposable;
 import reactor.core.Exceptions;
 import reactor.core.publisher.Operators;
+import reactor.util.context.Context;
 
 /**
  * A Scheduler implementation that given an ActorSystem, creates a single Actor and
@@ -201,7 +202,7 @@ public class ActorScheduler implements reactor.core.scheduler.Scheduler {
                 r.run();
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
-                Operators.onErrorDropped(ex);
+                Operators.onErrorDropped(ex, Context.empty());
             }
         }
     }

--- a/reactor-extra/src/main/java/reactor/math/MathSubscriber.java
+++ b/reactor-extra/src/main/java/reactor/math/MathSubscriber.java
@@ -42,7 +42,7 @@ abstract class MathSubscriber<T, R> extends Operators.MonoSubscriber<T, R> {
 	@Override
 	public void onNext(T t) {
 		if (done) {
-			Operators.onNextDropped(t);
+			Operators.onNextDropped(t, actual.currentContext());
 			return;
 		}
 
@@ -52,7 +52,7 @@ abstract class MathSubscriber<T, R> extends Operators.MonoSubscriber<T, R> {
 		catch (Throwable ex) {
 			reset();
 			done = true;
-			actual.onError(Operators.onOperatorError(s, ex, t));
+			actual.onError(Operators.onOperatorError(s, ex, t, actual.currentContext()));
 			return;
 		}
 	}
@@ -60,7 +60,7 @@ abstract class MathSubscriber<T, R> extends Operators.MonoSubscriber<T, R> {
 	@Override
 	public void onError(Throwable t) {
 		if (done) {
-			Operators.onErrorDropped(t);
+			Operators.onErrorDropped(t, actual.currentContext());
 			return;
 		}
 		done = true;

--- a/reactor-extra/src/main/java/reactor/swing/SwingScheduler.java
+++ b/reactor-extra/src/main/java/reactor/swing/SwingScheduler.java
@@ -27,6 +27,7 @@ import reactor.core.Disposable;
 import reactor.core.Exceptions;
 import reactor.core.publisher.Operators;
 import reactor.core.scheduler.Scheduler;
+import reactor.util.context.Context;
 
 /** 
  * Scheduler that runs tasks on Swing's event dispatch thread. 
@@ -65,7 +66,7 @@ public final class SwingScheduler implements Scheduler {
                 task.run();
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
-	            Operators.onErrorDropped(ex);
+	            Operators.onErrorDropped(ex, Context.empty());
             }
         });
         timer.start();
@@ -83,7 +84,7 @@ public final class SwingScheduler implements Scheduler {
             } catch (Throwable ex) {
                 timer.stop();
                 Exceptions.throwIfFatal(ex);
-	            Operators.onErrorDropped(ex);
+	            Operators.onErrorDropped(ex, Context.empty());
             }
         });
         timer.start();
@@ -177,7 +178,7 @@ public final class SwingScheduler implements Scheduler {
                         action.run();
                     } catch (Throwable ex) {
                         Exceptions.throwIfFatal(ex);
-	                    Operators.onErrorDropped(ex);
+	                    Operators.onErrorDropped(ex, Context.empty());
                     }
                 } finally {
                     remove(timer);
@@ -220,7 +221,7 @@ public final class SwingScheduler implements Scheduler {
                     timer.stop();
                     remove(timer);
                     Exceptions.throwIfFatal(ex);
-	                Operators.onErrorDropped(ex);
+	                Operators.onErrorDropped(ex, Context.empty());
                 }
             });
             
@@ -256,7 +257,7 @@ public final class SwingScheduler implements Scheduler {
                     action.run();
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
-	                Operators.onErrorDropped(ex);
+	                Operators.onErrorDropped(ex, Context.empty());
                 }
             }
         }

--- a/reactor-extra/src/main/java/reactor/swing/SwtScheduler.java
+++ b/reactor-extra/src/main/java/reactor/swing/SwtScheduler.java
@@ -25,6 +25,7 @@ import reactor.core.Disposable;
 import reactor.core.Exceptions;
 import reactor.core.publisher.Operators;
 import reactor.core.scheduler.Scheduler;
+import reactor.util.context.Context;
 
 /** 
  * Scheduler that runs tasks on Swt's event dispatch thread. 
@@ -194,7 +195,7 @@ public final class SwtScheduler implements Scheduler {
 				        action.run();
 				    } catch (Throwable ex) {
 				        Exceptions.throwIfFatal(ex);
-					    Operators.onErrorDropped(ex);
+					    Operators.onErrorDropped(ex, Context.empty());
 				    }
 				}
 			}
@@ -224,7 +225,7 @@ public final class SwtScheduler implements Scheduler {
                     action.run();
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
-	                Operators.onErrorDropped(ex);
+	                Operators.onErrorDropped(ex, Context.empty());
                 }
             }
         }
@@ -266,7 +267,7 @@ public final class SwtScheduler implements Scheduler {
                 task.run();
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
-	            Operators.onErrorDropped(ex);
+	            Operators.onErrorDropped(ex, Context.empty());
                 return;
             }
             
@@ -325,7 +326,7 @@ public final class SwtScheduler implements Scheduler {
                 task.run();
             } catch (Throwable ex) {
                 Exceptions.throwIfFatal(ex);
-	            Operators.onErrorDropped(ex);
+	            Operators.onErrorDropped(ex, Context.empty());
                 return;
             }
 

--- a/reactor-extra/src/test/java/reactor/scheduler/forkjoin/ForkJoinPoolSchedulerTest.java
+++ b/reactor-extra/src/test/java/reactor/scheduler/forkjoin/ForkJoinPoolSchedulerTest.java
@@ -92,7 +92,7 @@ public class ForkJoinPoolSchedulerTest extends AbstractSchedulerTest {
 				StepVerifier.create(Mono.delay(Duration.ofMillis(100), s)
 				                        .log()
 				                        .doOnSubscribe(sub -> start.set(System.nanoTime()))
-				                        .doOnTerminate((v, e) -> end.set(System.nanoTime())))
+				                        .doOnSuccessOrError((v, e) -> end.set(System.nanoTime())))
 				            .expectSubscription()
 				            .expectNext(0L)
 				            .verifyComplete();


### PR DESCRIPTION
 - Operators.onXxx now takes a Context (mostly empty one in addons)
 - Mono.doOnTerminate(BiConsumer) has been renamed `doOnSuccessOrError`