### PR TITLE
fix #135 by removing shadow plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,7 @@ buildscript {
   dependencies {
 	classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}",
 			'org.springframework.build.gradle:propdeps-plugin:0.0.7',
-			'io.spring.gradle:spring-io-plugin:0.0.4.RELEASE',
-			'com.github.jengelman.gradle.plugins:shadow:2.0.1'
+			'io.spring.gradle:spring-io-plugin:0.0.4.RELEASE'
   }
 }
 
@@ -205,7 +204,6 @@ project('reactor-logback') {
   description = 'Async Logback appender implementation'
 
   apply plugin: 'application'
-  apply plugin: 'com.github.johnrengelman.shadow'
 
   mainClassName = "reactor.logback.DurableLogUtility"
 
@@ -213,14 +211,6 @@ project('reactor-logback') {
 	compile "ch.qos.logback:logback-classic:$logbackVersion",
 			"net.openhft:chronicle:$openHftChronicleVersion",
 			"commons-cli:commons-cli:1.2"
-  }
-
-  shadowJar {
-	dependencies {
-	  include(dependency("net.openhft:chronicle:$openHftChronicleVersion"))
-	  include(dependency("commons-cli:commons-cli:1.2"))
-	  //include(project(":reactor-core"))
-	}
   }
 }
 
@@ -235,6 +225,8 @@ project('reactor-adapter') {
 
 	testCompile "org.reactivestreams:reactive-streams-tck:1.0.1"
   }
+
+
 }
 
 project('reactor-extra') {


### PR DESCRIPTION
Since at least the beginning of the 3.x line, the fat jar isn't even
distributed to repo.spring.io/release. Since there is a known issue
with its integration with the Application plugin (which artifact ARE
distributed so far), shortest course of action is to plainly remove it.