### PR TITLE
fix #139 backoff computation so that base delay is constrained to min/max +

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ buildscript {
 description = 'Reactive fast data framework for the JVM'
 
 ext {
-  reactorCoreVersion ='3.1.2.RELEASE'
+  reactorCoreVersion ='3.1.3.BUILD-SNAPSHOT'
 
   gradleVersion = '4.2'
   gradleScriptDir = "${rootProject.projectDir}/gradle"
@@ -50,7 +50,8 @@ ext {
   swtVersionPlatform = '4.5.2'
 
   // Testing
-  assertJVersion = '3.6.1'
+  assertJVersion = '3.9.0'
+  quickTheoriesVersion = '0.24'
   mockitoVersion = '1.10.19'
   spockVersion = '1.0-groovy-2.4'
 
@@ -176,6 +177,7 @@ configure(subprojects) { project ->
 	testCompile 'junit:junit:4.12',
 			"org.hamcrest:hamcrest-library:1.3",
 			"org.assertj:assertj-core:$assertJVersion",
+			"org.quicktheories:quicktheories:$quickTheoriesVersion",
 			"org.testng:testng:6.8.5"
 	testRuntime "ch.qos.logback:logback-classic:$logbackVersion"
 	testCompile "io.projectreactor:reactor-test:$reactorCoreVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ buildscript {
 description = 'Reactive fast data framework for the JVM'
 
 ext {
-  reactorCoreVersion ='3.1.3.BUILD-SNAPSHOT'
+  reactorCoreVersion ='3.1.2.RELEASE'
 
   gradleVersion = '4.2'
   gradleScriptDir = "${rootProject.projectDir}/gradle"

--- a/reactor-extra/src/main/java/reactor/retry/Jitter.java
+++ b/reactor-extra/src/main/java/reactor/retry/Jitter.java
@@ -38,21 +38,7 @@ public interface Jitter extends Function<BackoffDelay, Duration> {
 		}
 	};
 
-	Jitter RANDOM_JITTER = new Jitter() {
-		@Override
-		public Duration apply(BackoffDelay backoff) {
-			ThreadLocalRandom random = ThreadLocalRandom.current();
-			long backoffMs = backoff.delay().toMillis();
-			long minBackoffMs = backoff.min.toMillis();
-			long jitterBackoffMs = backoffMs == minBackoffMs ? minBackoffMs : random.nextLong(minBackoffMs, backoffMs);
-			return Duration.ofMillis(jitterBackoffMs);
-		}
-
-		@Override
-		public String toString() {
-			return "Jitter{RANDOM}";
-		}
-	};
+	Jitter RANDOM_JITTER = new RandomJitter(0.5);
 
 	/**
 	 * Jitter function that is a no-op.
@@ -63,11 +49,22 @@ public interface Jitter extends Function<BackoffDelay, Duration> {
 	}
 
 	/**
-	 * Jitter function that applies a random jitter to choose a random backoff
-	 * delay between {@link BackoffDelay#minDelay()} and {@link BackoffDelay#delay()}.
+	 * Jitter function that applies a random jitter with a factor of 0.5, generating a
+	 * backoff between {@code [d - d*0.5; d + d*0.5]} (but still within the limits of
+	 * [{@link BackoffDelay#minDelay()}; {@link BackoffDelay#maxDelay()}].
 	 * @return Jitter function to randomize backoff delay
 	 */
 	static Jitter random() {
 		return RANDOM_JITTER;
+	}
+
+	/**
+	 * Jitter function that applies a random jitter with a provided [0; 1] factor (default 0.5),
+	 * generating a backoff between {@code [d - d*factor; d + d*factor]} (but still within
+	 * the limits of [{@link BackoffDelay#minDelay()}; {@link BackoffDelay#maxDelay()}].
+	 * @return Jitter function to randomize backoff delay
+	 */
+	static Jitter random(double randomFactor) {
+		return new RandomJitter(randomFactor);
 	}
 }

--- a/reactor-extra/src/main/java/reactor/retry/RandomJitter.java
+++ b/reactor-extra/src/main/java/reactor/retry/RandomJitter.java
@@ -1,0 +1,100 @@
+package reactor.retry;
+
+import java.time.Duration;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Randomized Jitter with a factor, that works on BackoffDelay with min <= d <= max and
+ * maintain that invariant on the randomized {@literal d}.
+ *
+ * @author Simon Baslé
+ */
+class RandomJitter implements Jitter {
+
+	private final double randomFactor;
+
+	public RandomJitter(double randomFactor) {
+		if (randomFactor < 0 || randomFactor > 1) throw new IllegalArgumentException("random factor must be between 0 and 1 (default 0.5)");
+		this.randomFactor = randomFactor;
+	}
+
+	@Override
+	public Duration apply(BackoffDelay backoff) {
+		//check the invariant
+		if (backoff.delay.compareTo(backoff.min) < 0) {
+			throw new IllegalArgumentException("jitter can only be applied on a delay that is >= to min backoff");
+		}
+		if (backoff.delay.compareTo(backoff.max) > 0) {
+			throw new IllegalArgumentException("jitter can only be applied on a delay that is <= to max backoff");
+		}
+
+		//short-circuit delay == 0 case
+		if (backoff.delay.isZero()) {
+			return backoff.delay;
+		}
+
+		ThreadLocalRandom random = ThreadLocalRandom.current();
+
+		long jitterOffset = jitterOffsetCapped(backoff);
+		long lowBound = lowJitterBound(backoff, jitterOffset);
+		long highBound = highJitterBound(backoff, jitterOffset);
+
+		long jitter;
+		if (highBound == lowBound) {
+			if (highBound == 0) jitter = 0;
+			else jitter = random.nextLong(highBound);
+		}
+		else {
+			jitter = random.nextLong(lowBound, highBound);
+		}
+		return backoff.delay.plusMillis(jitter);
+	}
+
+	/**
+	 * Compute the jitter offset that will be used for the bounds of the random jitter,
+	 * in a way that is safe for large {@link Duration} that go over Long.MAX_VALUE ms.
+	 */
+	long jitterOffsetCapped(BackoffDelay backoff) {
+		try {
+			return backoff.delay.multipliedBy((long) (100 * randomFactor))
+			             .dividedBy(100)
+			             .toMillis();
+		}
+		catch (ArithmeticException ae) {
+			return Math.round(Long.MAX_VALUE * randomFactor);
+		}
+	}
+
+	/**
+	 * Compute a lower bound for the random jitter that won't let the final delay go
+	 * below {@link BackoffDelay#minDelay()}.
+	 *
+	 * @param backoff the original backoff constraints to work with
+	 * @param jitterOffset the jitter offset
+	 * @return a lower bound for the random generation function, so that delay + jitter &gt;= min
+	 */
+	long lowJitterBound(BackoffDelay backoff, long jitterOffset) {
+		return Math.max(
+				backoff.min.minus(backoff.delay).toMillis(),
+				-jitterOffset);
+	}
+
+	/**
+	 * Compute a higher bound for the random jitter that won't let the final delay go
+	 * over {@link BackoffDelay#maxDelay()}.
+	 *
+	 * @param backoff the original backoff constraints to work with
+	 * @param jitterOffset the jitter offset
+	 * @return a higher bound for the random generation function, so that delay + jitter &lt;= max
+	 */
+	long highJitterBound(BackoffDelay backoff, long jitterOffset) {
+		return Math.min(
+				backoff.max.minus(backoff.delay).toMillis(),
+				jitterOffset);
+	}
+
+	@Override
+	public String toString() {
+		return "Jitter{RANDOM-" + randomFactor + "}";
+	}
+}

--- a/reactor-extra/src/test/java/reactor/retry/DefaultRepeatTest.java
+++ b/reactor-extra/src/test/java/reactor/retry/DefaultRepeatTest.java
@@ -37,7 +37,7 @@ public class DefaultRepeatTest {
 		                  .jitter(Jitter.random());
 
 		assertThat(test.toString())
-				.isEqualTo("Repeat{times=3,backoff=" + backoff + ",jitter=Jitter{RANDOM}}");
+				.isEqualTo("Repeat{times=3,backoff=" + backoff + ",jitter=Jitter{RANDOM-0.5}}");
 	}
 
 }

--- a/reactor-extra/src/test/java/reactor/retry/DefaultRetryTest.java
+++ b/reactor-extra/src/test/java/reactor/retry/DefaultRetryTest.java
@@ -39,7 +39,7 @@ public class DefaultRetryTest {
 		                  .jitter(Jitter.random());
 
 		assertThat(test.toString())
-				.isEqualTo("Retry{max=3,backoff=" + backoff + ",jitter=Jitter{RANDOM}}");
+				.isEqualTo("Retry{max=3,backoff=" + backoff + ",jitter=Jitter{RANDOM-0.5}}");
 	}
 
 }

--- a/reactor-extra/src/test/java/reactor/retry/RandomJitterTest.java
+++ b/reactor-extra/src/test/java/reactor/retry/RandomJitterTest.java
@@ -1,0 +1,191 @@
+package reactor.retry;
+
+import java.time.Duration;
+
+import org.junit.Test;
+import org.quicktheories.QuickTheory;
+import org.quicktheories.core.Gen;
+import org.quicktheories.generators.SourceDSL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+public class RandomJitterTest {
+
+	@Test
+	public void negativeFactorRejected() {
+		assertThatIllegalArgumentException().isThrownBy(() -> new RandomJitter(-0.1))
+		                                    .withMessage("random factor must be between 0 and 1 (default 0.5)");
+	}
+
+	@Test
+	public void overOneFactorRejected() {
+		assertThatIllegalArgumentException().isThrownBy(() -> new RandomJitter(1.1))
+		                                    .withMessage("random factor must be between 0 and 1 (default 0.5)");
+	}
+
+	@Test
+	public void applyToDelayUnderMinRejected() {
+		//the BackoffDelay must comply to the invariant of min <= delay <= max
+		Duration min = Duration.ofMillis(100);
+		Duration max = Duration.ofMillis(100);
+		Duration delay = Duration.ofMillis(99);
+		BackoffDelay bd = new BackoffDelay(min, max, delay);
+		RandomJitter jitter = new RandomJitter(0.5);
+
+		assertThatIllegalArgumentException().isThrownBy(() -> jitter.apply(bd))
+		                                    .withMessage("jitter can only be applied on a delay that is >= to min backoff");
+	}
+
+	@Test
+	public void applyToDelayOverMaxRejected() {
+		//the BackoffDelay must comply to the invariant of min <= delay <= max
+		Duration min = Duration.ofMillis(100);
+		Duration max = Duration.ofMillis(200);
+		Duration delay = Duration.ofMillis(201);
+		BackoffDelay bd = new BackoffDelay(min, max, delay);
+		RandomJitter jitter = new RandomJitter(0.5);
+
+		assertThatIllegalArgumentException().isThrownBy(() -> jitter.apply(bd))
+		                                    .withMessage("jitter can only be applied on a delay that is <= to max backoff");
+	}
+
+	@Test
+	public void jitterOffsetCappedForSuperLargeMaxDuration() {
+		double factor = 0.5;
+		Duration min = Duration.ofMillis(100);
+		Duration max = Duration.ofMillis(100);
+		Duration delay = Duration.ofSeconds(Long.MAX_VALUE);
+		BackoffDelay bd = new BackoffDelay(min, max, delay);
+
+		RandomJitter jitter = new RandomJitter(factor);
+
+		assertThat(jitter.jitterOffsetCapped(bd))
+				.isEqualTo(Math.round(Long.MAX_VALUE * factor));
+	}
+
+	@Test
+	public void jitterOffsetForMaximumMillisDuration() {
+		double factor = 0.5;
+		Duration min = Duration.ofMillis(100);
+		Duration max = Duration.ofMillis(100);
+		Duration delay = Duration.ofMillis(Long.MAX_VALUE);
+		BackoffDelay bd = new BackoffDelay(min, max, delay);
+
+		RandomJitter jitter = new RandomJitter(factor);
+
+		long expected = delay.multipliedBy(50)
+				.dividedBy(100)
+				.toMillis();
+
+		assertThat(jitter.jitterOffsetCapped(bd))
+				.isEqualTo(expected);
+	}
+
+	@Test
+	public void jitterOffsetForReasonableDuration() {
+		double factor = 0.5;
+		Duration min = Duration.ofMillis(100);
+		Duration max = Duration.ofMillis(100);
+		Duration delay = Duration.ofMillis(500);
+		BackoffDelay bd = new BackoffDelay(min, max, delay);
+
+		RandomJitter jitter = new RandomJitter(factor);
+
+		assertThat(jitter.jitterOffsetCapped(bd))
+				.isEqualTo(250);
+	}
+
+	@Test
+	public void lowBoundNormal() {
+		double factor = 0.5;
+		Duration min = Duration.ofMillis(100); //not over half the duration
+		Duration max = Duration.ofMillis(-123); //should be ignored
+		Duration delay = Duration.ofMillis(500);
+		BackoffDelay bd = new BackoffDelay(min, max, delay);
+
+		RandomJitter jitter = new RandomJitter(factor);
+
+		assertThat(jitter.lowJitterBound(bd, 250))
+				.isEqualTo(-250);
+	}
+
+	@Test
+	public void lowBoundFlooredAtMin() {
+		double factor = 0.5;
+		Duration min = Duration.ofMillis(300); //over half the duration
+		Duration max = Duration.ofMillis(-123); //should be ignored
+		Duration delay = Duration.ofMillis(500);
+		BackoffDelay bd = new BackoffDelay(min, max, delay);
+
+		RandomJitter jitter = new RandomJitter(factor);
+
+		assertThat(jitter.lowJitterBound(bd, 250))
+				.as("offset over min")
+				.isEqualTo(-200);
+
+		assertThat(jitter.lowJitterBound(bd, Long.MAX_VALUE / 2))
+				.as("offset half long max")
+				.isEqualTo(-200);
+
+		assertThat(jitter.lowJitterBound(bd, Long.MAX_VALUE))
+				.as("offset long max")
+				.isEqualTo(-200);
+	}
+
+	@Test
+	public void highBoundNormal() {
+		double factor = 0.5;
+		Duration min = Duration.ofMillis(-123); //should be ignored
+		Duration max = Duration.ofMillis(1000); //not under half the duration
+		Duration delay = Duration.ofMillis(500);
+		BackoffDelay bd = new BackoffDelay(min, max, delay);
+
+		RandomJitter jitter = new RandomJitter(factor);
+
+		assertThat(jitter.highJitterBound(bd, 250))
+				.isEqualTo(250);
+	}
+
+	@Test
+	public void highBoundCappedAtMax() {
+		double factor = 0.5;
+		Duration min = Duration.ofMillis(-123); //should be ignored
+		Duration max = Duration.ofMillis(550); //under half the duration
+		Duration delay = Duration.ofMillis(500);
+		BackoffDelay bd = new BackoffDelay(min, max, delay);
+
+		RandomJitter jitter = new RandomJitter(factor);
+
+		assertThat(jitter.highJitterBound(bd, 250))
+				.as("offset over min")
+				.isEqualTo(50);
+
+		assertThat(jitter.highJitterBound(bd, Long.MAX_VALUE / 2))
+				.as("offset half long max")
+				.isEqualTo(50);
+
+		assertThat(jitter.highJitterBound(bd, Long.MAX_VALUE))
+				.as("offset long max")
+				.isEqualTo(50);
+	}
+
+	@Test
+	public void propertyJitterDoesntCrossMinMax() {
+		Gen<Long> minGen = SourceDSL.longs()
+		                            .between(0, Long.MAX_VALUE - 2);
+
+		Gen<Long> delayGen = minGen.flatMap(d -> SourceDSL.longs().between(d, Long.MAX_VALUE - 1));
+		Gen<Long> maxGen = delayGen.flatMap(d -> SourceDSL.longs().between(d, Long.MAX_VALUE));
+
+		QuickTheory.qt()
+		           .withGenerateAttempts(1000)
+		           .forAll(minGen, delayGen, maxGen)
+		           .assuming((min, d, max) -> min <= d && d <= max)
+		           .as((min, d, max) -> new BackoffDelay(Duration.ofMillis(min), Duration.ofMillis(max), Duration.ofMillis(d)))
+		           .checkAssert(bd -> assertThat(Jitter.random().apply(bd))
+				           .isGreaterThanOrEqualTo(bd.min)
+				           .isLessThanOrEqualTo(bd.max));
+	}
+
+}

--- a/reactor-extra/src/test/java/reactor/retry/RetryTestUtils.java
+++ b/reactor-extra/src/test/java/reactor/retry/RetryTestUtils.java
@@ -57,10 +57,7 @@ public class RetryTestUtils {
 		int randomValues = 0;
 		for (Context<?> context : retries) {
 			long backoffMs = context.backoff().toMillis();
-			if (prevMs == 0)
-				assertEquals(firstMs, backoffMs);
-			else
-				assertTrue("Unexpected delay " + backoffMs, backoffMs >= firstMs && backoffMs <= maxMs);
+			assertTrue("Unexpected delay " + backoffMs, backoffMs >= firstMs && backoffMs <= maxMs);
 			if (backoffMs != firstMs && backoffMs != prevMs)
 				randomValues++;
 			prevMs = backoffMs;


### PR DESCRIPTION
jitter is applied after. Jitter is now maintaining the min <= d <= max
invariant and has a RandomJitter implementation that is based on a factor,
rather than generating completely randomly between min/max (keeps jitter
within [d-d/2;d + d/2] by default).
