### PR TITLE
Retry/Repeat second round of improvements (#149, #150)

### DIFF
--- a/reactor-extra/src/main/java/reactor/retry/DefaultRepeat.java
+++ b/reactor-extra/src/main/java/reactor/retry/DefaultRepeat.java
@@ -76,8 +76,16 @@ public class DefaultRepeat<T> extends AbstractRetry<T, Long> implements Repeat<T
 	public Repeat<T> timeout(Duration timeout) {
 		if (timeout.isNegative())
 			throw new IllegalArgumentException("timeout should be >= 0");
-		return new DefaultRepeat<>(repeatPredicate, Integer.MAX_VALUE, timeout,
+		return new DefaultRepeat<>(repeatPredicate, maxIterations, timeout,
 				backoff, jitter, backoffScheduler, onRepeat, applicationContext);
+	}
+
+	@Override
+	public Repeat<T> repeatMax(long maxRepeats) {
+		if (maxRepeats < 1)
+			throw new IllegalArgumentException("maxRepeats should be > 0");
+		return new DefaultRepeat<>(repeatPredicate, maxRepeats, timeout, backoff, jitter,
+				backoffScheduler, onRepeat, applicationContext);
 	}
 
 	@Override

--- a/reactor-extra/src/main/java/reactor/retry/DefaultRetry.java
+++ b/reactor-extra/src/main/java/reactor/retry/DefaultRetry.java
@@ -52,7 +52,7 @@ public class DefaultRetry<T> extends AbstractRetry<T, Throwable> implements Retr
 
 	public static <T> DefaultRetry<T> create(Predicate<? super RetryContext<T>> retryPredicate) {
 		return new DefaultRetry<T>(retryPredicate,
-				1,
+				Long.MAX_VALUE,
 				null,
 				Backoff.zero(),
 				Jitter.noJitter(),

--- a/reactor-extra/src/main/java/reactor/retry/DefaultRetry.java
+++ b/reactor-extra/src/main/java/reactor/retry/DefaultRetry.java
@@ -85,7 +85,7 @@ public class DefaultRetry<T> extends AbstractRetry<T, Throwable> implements Retr
 	public Retry<T> timeout(Duration timeout) {
 		if (timeout.isNegative())
 			throw new IllegalArgumentException("timeout should be >= 0");
-		return new DefaultRetry<>(retryPredicate, Integer.MAX_VALUE, timeout,
+		return new DefaultRetry<>(retryPredicate, maxIterations, timeout,
 				backoff, jitter, backoffScheduler, onRetry, applicationContext);
 	}
 

--- a/reactor-extra/src/main/java/reactor/retry/Repeat.java
+++ b/reactor-extra/src/main/java/reactor/retry/Repeat.java
@@ -31,6 +31,10 @@ import reactor.core.scheduler.Scheduler;
  * Repeat function that may be used with {@link Flux#repeatWhen(Function)},
  * {@link Mono#repeatWhen(Function)} and {@link Mono#repeatWhenEmpty(Function)}.
  * <p>
+ * Each change in configuration returns a new instance (copy configuration), which
+ * makes {@link Repeat} suitable for creating configuration templates that can be fine
+ * tuned for specific cases without impacting the original general use-case configuration.
+ * <p>
  * Example usage:
  * <pre><code>
  *   repeat = Repeat.times(10)
@@ -50,7 +54,7 @@ public interface Repeat<T> extends Function<Flux<Long>, Publisher<Long>> {
 	 * @return Repeat function with predicate
 	 */
 	static <T> Repeat<T> onlyIf(Predicate<? super RepeatContext<T>> predicate) {
-		return DefaultRepeat.create(predicate, Integer.MAX_VALUE);
+		return DefaultRepeat.create(predicate, Long.MAX_VALUE);
 	}
 
 	/**
@@ -110,8 +114,10 @@ public interface Repeat<T> extends Function<Flux<Long>, Publisher<Long>> {
 
 	/**
 	 * Returns a repeat function with timeout. The timeout starts from
-	 * the instant that this function is applied. All other properties of
+	 * the instant that this function is applied and switches to unlimited
+	 * number of attempts. All other properties of
 	 * this repeat function are retained in the returned instance.
+	 *
 	 * @param timeout timeout after which no new repeats are initiated
 	 * @return repeat function with timeout
 	 */

--- a/reactor-extra/src/main/java/reactor/retry/Repeat.java
+++ b/reactor-extra/src/main/java/reactor/retry/Repeat.java
@@ -44,6 +44,13 @@ import reactor.core.scheduler.Scheduler;
  *   flux.repeatWhen(repeat);
  * </code></pre>
  *
+ * @apiNote Repeat can be directly created with a maximum number of attempts, yet there
+ * is a {@link #repeatMax(long)} method to change that post-construction, for the case
+ * where one wants to fine tune that aspect for specific use-cases. For instance, the
+ * default configuration could be an unlimited amount of attempts ({@link Long#MAX_VALUE})
+ * with a global {@link #timeout(Duration)}, but for some specific cases you might want
+ * to change both the timeout and limit the attempts.
+ *
  * @param <T> Application context type
  */
 public interface Repeat<T> extends Function<Flux<Long>, Publisher<Long>> {
@@ -122,6 +129,15 @@ public interface Repeat<T> extends Function<Flux<Long>, Publisher<Long>> {
 	 * @return repeat function with timeout
 	 */
 	Repeat<T> timeout(Duration timeout);
+
+	/**
+	 * Returns a repeat function that repeats at most n times. All other
+	 * properties of this repeat function are retained in the returned instance.
+	 *
+	 * @param maxRepeats number of repeats
+	 * @return Retry function for n repeats
+	 */
+	Repeat<T> repeatMax(long maxRepeats);
 
 	/**
 	 * Returns a repeat function with backoff delay.

--- a/reactor-extra/src/main/java/reactor/retry/Retry.java
+++ b/reactor-extra/src/main/java/reactor/retry/Retry.java
@@ -28,10 +28,15 @@ import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
 
 /**
- * Retry function that may be used with {@link Flux#retryWhen(Function)} and
- * {@link Mono#retryWhen(Function)}.
+ * Retry function that may be used with {@link Flux#retryWhen(Function)} and {@link
+ * Mono#retryWhen(Function)}.
+ * <p>
+ * Each change in configuration returns a new instance (copy configuration), which
+ * makes {@link Retry} suitable for creating configuration templates that can be fine
+ * tuned for specific cases without impacting the original general use-case configuration.
  * <p>
  * Example usage:
+ *
  * <pre><code>
  *   retry = Retry.anyOf(IOException.class)
  *                 .randomBackoff(Duration.ofMillis(100), Duration.ofSeconds(60))
@@ -103,13 +108,13 @@ public interface Retry<T> extends Function<Flux<Throwable>, Publisher<Long>> {
 	}
 
 	/**
-	 * Retry function that retries only if the predicate returns true, up to
-	 * {@link Integer#MAX_VALUE} times.
+	 * Retry function that retries only if the predicate returns true, with no limit to
+	 * the number of attempts.
 	 * @param predicate Predicate that determines if next retry is performed
 	 * @return Retry function with predicate
 	 */
 	static <T> Retry<T> onlyIf(Predicate<? super RetryContext<T>> predicate) {
-		return DefaultRetry.create(predicate).retryMax(Integer.MAX_VALUE);
+		return DefaultRetry.create(predicate).retryMax(Long.MAX_VALUE);
 	}
 
 	/**

--- a/reactor-extra/src/main/java/reactor/retry/Retry.java
+++ b/reactor-extra/src/main/java/reactor/retry/Retry.java
@@ -161,11 +161,11 @@ public interface Retry<T> extends Function<Flux<Throwable>, Publisher<Long>> {
 	/**
 	 * Returns a retry function with timeout. The timeout starts from
 	 * the instant that this function is applied, and the function keeps retrying
-	 * until the timeout expires. Use {@link #retryMax(long)} AFTER this method to
-	 * change that to a "retry until timeout OR n attempts" behaviour.
-	 * All other properties of this retry function are retained in the returned instance.
+	 * until the timeout expires (or until the configured maximum number of attempts, if
+	 * it has been set). All other properties of this retry function are retained in
+	 * the returned instance.
 	 * @param timeout timeout after which no new retries are initiated
-	 * @return retry function with unlimited attempts until timeout
+	 * @return retry function with global timeout
 	 */
 	Retry<T> timeout(Duration timeout);
 

--- a/reactor-extra/src/test/java/reactor/retry/DefaultRetryTest.java
+++ b/reactor-extra/src/test/java/reactor/retry/DefaultRetryTest.java
@@ -42,9 +42,8 @@ public class DefaultRetryTest {
 				.isEqualTo("Retry{max=3,backoff=" + backoff + ",jitter=Jitter{RANDOM-0.5}}");
 	}
 
-	//TODO change in 3.2.0 to "doesnt change maxIterations" when gh-149 and gh-150 are fixed
 	@Test
-	public void timeoutDoesChangeMaxIterations() {
+	public void timeoutDoesntChangeMaxIterations() {
 		final DefaultRetry<Object> retry1 = (DefaultRetry<Object>) Retry.any()
 		                                                                .retryMax(3);
 
@@ -53,13 +52,13 @@ public class DefaultRetryTest {
 		final DefaultRetry<Object> retry2 =
 				(DefaultRetry<Object>) retry1.timeout(Duration.ofMillis(200));
 
-		assertThat(retry2.maxIterations).as("switched to unlimited by timeout")
-		                                .isEqualTo(Integer.MAX_VALUE);
+		assertThat(retry2.maxIterations).as("not changed by timeout")
+		                                .isEqualTo(3);
 
 		final DefaultRetry<Object> retry3 =
 				(DefaultRetry<Object>) retry2.retryMax(4);
 
-		assertThat(retry3.maxIterations).as("back to limited by retryMax")
+		assertThat(retry3.maxIterations).as("changed by retryMax")
 		                                .isEqualTo(4);
 	}
 


### PR DESCRIPTION
@smaldini to be rebase-merged

 * finalize fix #149 Retry now defaults to unlimited retries
    + missing Integer.MAX_VALUE to Long.MAX_VALUE conversions
 * fix #150 Repeat/Retry `timeout` doesn't change the max attempt config
    + add `Repeat#repeatMax` to be able to fine tune it post-construction.