### PR TITLE
Issue 173. Check maxIterations before backoff calculation.

### DIFF
--- a/reactor-extra/src/test/java/reactor/retry/RetryTestUtils.java
+++ b/reactor-extra/src/test/java/reactor/retry/RetryTestUtils.java
@@ -115,7 +115,8 @@ public class RetryTestUtils {
 		assertEquals(0, latch.getCount());
 		assertEquals(threads, backoffCounts.size());
 		for (Integer count : backoffCounts.values()) {
-			assertEquals(repeatCount + 1, count.intValue());
+			//backoff not invoked anymore when maxIteration reached
+			assertEquals(repeatCount, count.intValue());
 		}
 	}
 }


### PR DESCRIPTION
https://github.com/reactor/reactor-addons/pull/174
