### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,7 +17,7 @@
 buildscript {
   ext.kotlinVersion = '1.1.61'
   repositories {
-	maven { url "http://repo.spring.io/plugins-release" }
+	maven { url "https://repo.spring.io/plugins-release" }
   }
   dependencies {
 	classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}",
@@ -55,12 +55,12 @@ ext {
   mockitoVersion = '1.10.19'
   spockVersion = '1.0-groovy-2.4'
 
-  javadocLinks = ["http://projectreactor.io/docs/core/${reactorCoreVersion}/api/",
+  javadocLinks = ["https://projectreactor.io/docs/core/${reactorCoreVersion}/api/",
 		  		  "https://docs.oracle.com/javase/7/docs/api/",
 				  "https://docs.oracle.com/javaee/6/api/",
-				  "http://fasterxml.github.io/jackson-databind/javadoc/2.5/",
-				  "http://www.goldmansachs.com/gs-collections/javadoc/5.1.0/",
-				  "http://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/"] as
+				  "https://fasterxml.github.io/jackson-databind/javadoc/2.5/",
+				  "https://www.goldmansachs.com/gs-collections/javadoc/5.1.0/",
+				  "https://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/"] as
 		  String[]
 }
 
@@ -154,10 +154,10 @@ configure(subprojects) { project ->
   repositories {
 	if (version.endsWith('BUILD-SNAPSHOT') || project.hasProperty('platformVersion')) {
 	  mavenLocal()
-	  maven { url 'http://repo.spring.io/libs-snapshot' }
+	  maven { url 'https://repo.spring.io/libs-snapshot' }
 	}
 
-	maven { url 'http://repo.spring.io/libs-milestone' }
+	maven { url 'https://repo.spring.io/libs-milestone' }
 	maven { url "https://oss.sonatype.org/content/repositories/releases/" }
 	jcenter()
 	mavenCentral()
@@ -188,7 +188,7 @@ configure(subprojects) { project ->
 	apply plugin: 'spring-io'
 
 	repositories {
-	  maven { url 'http://repo.spring.io/libs-snapshot' }
+	  maven { url 'https://repo.spring.io/libs-snapshot' }
 	}
 
 	dependencyManagement {
@@ -237,7 +237,7 @@ project('reactor-extra') {
   description = 'Reactor Extra utilities'
 
   repositories {
-	maven { url "http://maven-eclipse.github.io/maven" }
+	maven { url "https://maven-eclipse.github.io/maven" }
   }
 
   dependencies {

--- a/gradle/doc.gradle
+++ b/gradle/doc.gradle
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -68,12 +68,12 @@ def customizePom(pom, gradleProject) {
 			url = 'https://github.com/reactor/reactor'
 			organization {
 				name = 'reactor'
-				url = 'http://github.com/reactor'
+				url = 'https://github.com/reactor'
 			}
 			licenses {
 				license {
 					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}
 			}

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://projectreactor.io/docs/core/ (301) migrated to:  
  https://projectreactor.io/docs/core/ ([https](https://projectreactor.io/docs/core/) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://fasterxml.github.io/jackson-databind/javadoc/2.5/ migrated to:  
  https://fasterxml.github.io/jackson-databind/javadoc/2.5/ ([https](https://fasterxml.github.io/jackson-databind/javadoc/2.5/) result 200).
* http://github.com/reactor migrated to:  
  https://github.com/reactor ([https](https://github.com/reactor) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://www.goldmansachs.com/gs-collections/javadoc/5.1.0/ migrated to:  
  https://www.goldmansachs.com/gs-collections/javadoc/5.1.0/ ([https](https://www.goldmansachs.com/gs-collections/javadoc/5.1.0/) result 200).
* http://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/ migrated to:  
  https://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/ ([https](https://www.reactive-streams.org/reactive-streams-1.0.2-javadoc/) result 200).
* http://maven-eclipse.github.io/maven migrated to:  
  https://maven-eclipse.github.io/maven ([https](https://maven-eclipse.github.io/maven) result 301).
* http://repo.spring.io/libs-milestone migrated to:  
  https://repo.spring.io/libs-milestone ([https](https://repo.spring.io/libs-milestone) result 302).
* http://repo.spring.io/libs-snapshot migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).
* http://repo.spring.io/plugins-release migrated to:  
  https://repo.spring.io/plugins-release ([https](https://repo.spring.io/plugins-release) result 302).