### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Join the chat at https://gitter.im/reactor/reactor](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/reactor/reactor?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-[![Latest addons](https://maven-badges.herokuapp.com/maven-central/io.projectreactor.addons/reactor-extra/badge.svg?style=plastic)](http://mvnrepository.com/artifact/io.projectreactor.addons/reactor-extra)
+[![Latest addons](https://maven-badges.herokuapp.com/maven-central/io.projectreactor.addons/reactor-extra/badge.svg?style=plastic)](https://mvnrepository.com/artifact/io.projectreactor.addons/reactor-extra)
 
 # Addons List
 
@@ -44,9 +44,9 @@ To add this repo to your Gradle build, specify the URL like the following:
     }
 
     repositories {
-      //maven { url 'http://repo.spring.io/release' }
-      maven { url 'http://repo.spring.io/milestone' }
-      maven { url 'http://repo.spring.io/snapshot' }
+      //maven { url 'https://repo.spring.io/release' }
+      maven { url 'https://repo.spring.io/milestone' }
+      maven { url 'https://repo.spring.io/snapshot' }
       mavenCentral()
     }
 
@@ -58,9 +58,9 @@ To add this repo to your Gradle build, specify the URL like the following:
 
 ## Documentation
 
-* [Guides](http://projectreactor.io/docs/) (Notably `reactor-core` reference guide which
-contains a section [about testing](http://projectreactor.io/docs/core/release/reference/docs/index.html#testing))
-* [Reactive Streams](http://www.reactive-streams.org/)
+* [Guides](https://projectreactor.io/docs/) (Notably `reactor-core` reference guide which
+contains a section [about testing](https://projectreactor.io/docs/core/release/reference/docs/index.html#testing))
+* [Reactive Streams](https://www.reactive-streams.org/)
 
 ## Community / Support
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To add this repo to your Gradle build, specify the URL like the following:
 
 ## Documentation
 
-* [Guides](https://projectreactor.io/docs/) (Notably `reactor-core` reference guide which
+* [Guides](https://projectreactor.io/docs) (Notably `reactor-core` reference guide which
 contains a section [about testing](https://projectreactor.io/docs/core/release/reference/docs/index.html#testing))
 * [Reactive Streams](https://www.reactive-streams.org/)
 

--- a/docs/src/api/stylesheet.css
+++ b/docs/src/api/stylesheet.css
@@ -108,7 +108,7 @@ Document title and Copyright styles
     position: absolute;
     right: 2px;
     top: 10px;
-    background: url(http://projectreactor.io/assets/img/logo-2x.png) no-repeat 0 -30px;
+    background: url(https://projectreactor.io/assets/img/logo-2x.png) no-repeat 0 -30px;
     background-size: 189px 60px;
     height: 40px;
     width: 44px;

--- a/reactor-adapter/src/test/resources/akka-streams.conf
+++ b/reactor-adapter/src/test/resources/akka-streams.conf
@@ -636,7 +636,7 @@ akka {
     debug {
       # enable function of Actor.loggable(), which is to log any received message
       # at DEBUG level, see the “Testing Actor Systems” section of the Akka
-      # Documentation at http://akka.io/docs
+      # Documentation at https://akka.io/docs
       receive = off
 
       # enable DEBUG logging of all AutoReceiveMessages (Kill, PoisonPill et.c.)


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [x] http://projectreactor.io/docs/ (301) with 1 occurrences migrated to:  
  https://projectreactor.io/docs/ ([https](https://projectreactor.io/docs/) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://mvnrepository.com/artifact/io.projectreactor.addons/reactor-extra with 1 occurrences migrated to:  
  https://mvnrepository.com/artifact/io.projectreactor.addons/reactor-extra ([https](https://mvnrepository.com/artifact/io.projectreactor.addons/reactor-extra) result 200).
* [ ] http://projectreactor.io/assets/img/logo-2x.png with 1 occurrences migrated to:  
  https://projectreactor.io/assets/img/logo-2x.png ([https](https://projectreactor.io/assets/img/logo-2x.png) result 200).
* [ ] http://www.reactive-streams.org/ with 1 occurrences migrated to:  
  https://www.reactive-streams.org/ ([https](https://www.reactive-streams.org/) result 200).
* [ ] http://akka.io/docs with 1 occurrences migrated to:  
  https://akka.io/docs ([https](https://akka.io/docs) result 301).
* [ ] http://projectreactor.io/docs/core/release/reference/docs/index.html with 1 occurrences migrated to:  
  https://projectreactor.io/docs/core/release/reference/docs/index.html ([https](https://projectreactor.io/docs/core/release/reference/docs/index.html) result 302).
* [ ] http://repo.spring.io/milestone with 1 occurrences migrated to:  
  https://repo.spring.io/milestone ([https](https://repo.spring.io/milestone) result 302).
* [ ] http://repo.spring.io/release with 1 occurrences migrated to:  
  https://repo.spring.io/release ([https](https://repo.spring.io/release) result 302).
* [ ] http://repo.spring.io/snapshot with 1 occurrences migrated to:  
  https://repo.spring.io/snapshot ([https](https://repo.spring.io/snapshot) result 302).