### PR TITLE
Reintroduce Kotlin extensions, but deprecated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,11 +15,13 @@
  */
 
 buildscript {
+  ext.kotlinVersion = '1.1.61'
   repositories {
 	maven { url "https://repo.spring.io/plugins-release" }
   }
   dependencies {
-	classpath 'org.springframework.build.gradle:propdeps-plugin:0.0.7',
+	classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}",
+			'org.springframework.build.gradle:propdeps-plugin:0.0.7',
 			'io.spring.gradle:spring-io-plugin:0.0.4.RELEASE'
   }
 }
@@ -76,6 +78,7 @@ configure(subprojects) { project ->
 
   apply plugin: 'propdeps'
   apply plugin: 'java'
+  apply plugin: 'kotlin'
   apply from: "${gradleScriptDir}/ide.gradle"
 
   [compileJava, compileTestJava]*.options*.compilerArgs = ["-Xlint:varargs",
@@ -106,6 +109,22 @@ configure(subprojects) { project ->
   compileTestJava {
 	sourceCompatibility = 1.8
 	targetCompatibility = 1.8
+  }
+
+  compileKotlin {
+	kotlinOptions.jvmTarget = "1.8"
+	kotlinOptions.freeCompilerArgs = ["-Xjsr305=strict"]
+  }
+
+  compileTestKotlin {
+	kotlinOptions.jvmTarget = "1.8"
+	kotlinOptions.freeCompilerArgs = ["-Xjsr305=strict"]
+  }
+
+  // now that kotlin-gradle-plugin 1.1.60 is out with fix for https://youtrack.jetbrains.com/issue/KT-17564
+  // be wary and fail if the issue of source file duplication in jar comes up again
+  sourcesJar {
+	duplicatesStrategy = DuplicatesStrategy.FAIL
   }
 
   if (JavaVersion.current().isJava8Compatible()) {
@@ -191,6 +210,8 @@ project('reactor-adapter') {
 
 	optional "com.typesafe.akka:akka-actor_2.11:$akkaActorVersion"
 
+	optional "org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion}"
+
 	testCompile "org.reactivestreams:reactive-streams-tck:1.0.2"
   }
 
@@ -213,8 +234,7 @@ project('reactor-extra') {
 
   dependencies {
 	optional "org.eclipse.swt:org.eclipse.swt.${getPlatform()}:${swtVersionPlatform}"
-	testCompile "org.reactivestreams:reactive-streams-tck:1.0.2"
-	testCompile "org.mockito:mockito-core:2.23.0"
+	optional("org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion}")
   }
   
   jar {

--- a/build.gradle
+++ b/build.gradle
@@ -181,6 +181,7 @@ configure(subprojects) { project ->
 			"org.testng:testng:6.8.5"
 	testRuntime "ch.qos.logback:logback-classic:$logbackVersion"
 	testCompile "io.projectreactor:reactor-test:$reactorCoreVersion"
+	testCompile "io.projectreactor.kotlin:reactor-kotlin-extensions:1.0.0.BUILD-SNAPSHOT"
 
   }
 
@@ -235,6 +236,8 @@ project('reactor-extra') {
   dependencies {
 	optional "org.eclipse.swt:org.eclipse.swt.${getPlatform()}:${swtVersionPlatform}"
 	optional("org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion}")
+	testCompile "org.reactivestreams:reactive-streams-tck:1.0.2"
+	testCompile "org.mockito:mockito-core:2.23.0"
   }
   
   jar {

--- a/reactor-adapter/src/main/kotlin/reactor/adapter/rxjava/RxJava2AdapterExt.kt
+++ b/reactor-adapter/src/main/kotlin/reactor/adapter/rxjava/RxJava2AdapterExt.kt
@@ -16,6 +16,8 @@ import reactor.core.publisher.Mono
  * @param <T> the value type
  * @return the new Flux instance
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toFlux()", "reactor.kotlin.adapter.rxjava.toFlux"))
 fun <T> Flowable<T>.toFlux(): Flux<T> {
     return RxJava2Adapter.flowableToFlux<T>(this)
 }
@@ -26,6 +28,8 @@ fun <T> Flowable<T>.toFlux(): Flux<T> {
  * @param <T> the value type
  * @return the new Flux instance
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toFlowable()", "reactor.kotlin.adapter.rxjava.toFlowable"))
 fun <T> Flux<T>.toFlowable(): Flowable<T> {
     return RxJava2Adapter.fluxToFlowable(this)
 }
@@ -36,6 +40,8 @@ fun <T> Flux<T>.toFlowable(): Flowable<T> {
  * @param <T> the value type
  * @return the new Flux instance
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toFlowable()", "reactor.kotlin.adapter.rxjava.toFlowable"))
 fun <T> Mono<T>.toFlowable(): Flowable<T> {
     return RxJava2Adapter.monoToFlowable<T>(this)
 }
@@ -44,6 +50,8 @@ fun <T> Mono<T>.toFlowable(): Flowable<T> {
  * Wraps a void-Mono instance into a RxJava Completable.
  * @return the new Completable instance
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toCompletable()", "reactor.kotlin.adapter.rxjava.toCompletable"))
 fun Mono<*>.toCompletable(): Completable {
     return RxJava2Adapter.monoToCompletable(this)
 }
@@ -52,6 +60,8 @@ fun Mono<*>.toCompletable(): Completable {
  * Wraps a RxJava Completable into a Mono instance.
  * @return the new Mono instance
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toMono()", "reactor.kotlin.adapter.rxjava.toMono"))
 fun Completable.toMono(): Mono<Void> {
     return RxJava2Adapter.completableToMono(this)
 }
@@ -64,6 +74,8 @@ fun Completable.toMono(): Mono<Void> {
  * @param <T> the value type
  * @return the new Single instance
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toSingle()", "reactor.kotlin.adapter.rxjava.toSingle"))
 fun <T> Mono<T>.toSingle(): Single<T> {
     return RxJava2Adapter.monoToSingle(this)
 }
@@ -73,6 +85,8 @@ fun <T> Mono<T>.toSingle(): Single<T> {
  * @param <T> the value type
  * @return the new Mono instance
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toMono()", "reactor.kotlin.adapter.rxjava.toMono"))
 fun <T> Single<T>.toMono(): Mono<T> {
     return RxJava2Adapter.singleToMono<T>(this)
 }
@@ -83,6 +97,8 @@ fun <T> Single<T>.toMono(): Mono<T> {
  * @param strategy the back-pressure strategy, default is BUFFER
  * @return the new Flux instance
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toFlux(strategy)", "reactor.kotlin.adapter.rxjava.toFlux"))
 fun <T> Observable<T>.toFlux(strategy: BackpressureStrategy = BackpressureStrategy.BUFFER): Flux<T> {
     return RxJava2Adapter.observableToFlux(this, strategy)
 }
@@ -92,6 +108,8 @@ fun <T> Observable<T>.toFlux(strategy: BackpressureStrategy = BackpressureStrate
  * @param <T> the value type
  * @return the new Observable instance
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toObservable()", "reactor.kotlin.adapter.rxjava.toObservable"))
 fun <T> Flux<T>.toObservable(): Observable<T> {
     return RxJava2Adapter.fluxToFlowable(this).toObservable()
 }
@@ -101,6 +119,8 @@ fun <T> Flux<T>.toObservable(): Observable<T> {
  * @param <T> the value type
  * @return the new Mono instance
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toMono()", "reactor.kotlin.adapter.rxjava.toMono"))
 fun <T> Maybe<T>.toMono(): Mono<T> {
     return RxJava2Adapter.maybeToMono(this)
 }
@@ -110,6 +130,8 @@ fun <T> Maybe<T>.toMono(): Mono<T> {
  * @param <T> the value type
  * @return the new Maybe instance
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toMaybe()", "reactor.kotlin.adapter.rxjava.toMaybe"))
 fun <T> Mono<T>.toMaybe(): Maybe<T> {
     return RxJava2Adapter.monoToMaybe(this)
 }

--- a/reactor-adapter/src/main/kotlin/reactor/adapter/rxjava/RxJava2AdapterExt.kt
+++ b/reactor-adapter/src/main/kotlin/reactor/adapter/rxjava/RxJava2AdapterExt.kt
@@ -1,0 +1,115 @@
+package reactor.adapter.rxjava
+
+import io.reactivex.BackpressureStrategy
+import io.reactivex.Completable
+import io.reactivex.Flowable
+import io.reactivex.Maybe
+import io.reactivex.Observable
+import io.reactivex.Single
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+
+
+/**
+ * Wraps a Flowable instance into a Flux instance, composing the micro-fusion
+ * properties of the Flowable through.
+ * @param <T> the value type
+ * @return the new Flux instance
+ */
+fun <T> Flowable<T>.toFlux(): Flux<T> {
+    return RxJava2Adapter.flowableToFlux<T>(this)
+}
+
+/**
+ * Wraps a Flux instance into a Flowable instance, composing the micro-fusion
+ * properties of the Flux through.
+ * @param <T> the value type
+ * @return the new Flux instance
+ */
+fun <T> Flux<T>.toFlowable(): Flowable<T> {
+    return RxJava2Adapter.fluxToFlowable(this)
+}
+
+/**
+ * Wraps a Mono instance into a Flowable instance, composing the micro-fusion
+ * properties of the Flux through.
+ * @param <T> the value type
+ * @return the new Flux instance
+ */
+fun <T> Mono<T>.toFlowable(): Flowable<T> {
+    return RxJava2Adapter.monoToFlowable<T>(this)
+}
+
+/**
+ * Wraps a void-Mono instance into a RxJava Completable.
+ * @return the new Completable instance
+ */
+fun Mono<*>.toCompletable(): Completable {
+    return RxJava2Adapter.monoToCompletable(this)
+}
+
+/**
+ * Wraps a RxJava Completable into a Mono instance.
+ * @return the new Mono instance
+ */
+fun Completable.toMono(): Mono<Void> {
+    return RxJava2Adapter.completableToMono(this)
+}
+
+/**
+ * Wraps a Mono instance into a RxJava Single.
+ *
+ * If the Mono is empty, the single will signal a
+ * [NoSuchElementException].
+ * @param <T> the value type
+ * @return the new Single instance
+ */
+fun <T> Mono<T>.toSingle(): Single<T> {
+    return RxJava2Adapter.monoToSingle(this)
+}
+
+/**
+ * Wraps a RxJava Single into a Mono instance.
+ * @param <T> the value type
+ * @return the new Mono instance
+ */
+fun <T> Single<T>.toMono(): Mono<T> {
+    return RxJava2Adapter.singleToMono<T>(this)
+}
+
+/**
+ * Wraps an RxJava Observable and applies the given backpressure strategy.
+ * @param <T> the value type
+ * @param strategy the back-pressure strategy, default is BUFFER
+ * @return the new Flux instance
+ */
+fun <T> Observable<T>.toFlux(strategy: BackpressureStrategy = BackpressureStrategy.BUFFER): Flux<T> {
+    return RxJava2Adapter.observableToFlux(this, strategy)
+}
+
+/**
+ * Wraps a Flux instance into a RxJava Observable.
+ * @param <T> the value type
+ * @return the new Observable instance
+ */
+fun <T> Flux<T>.toObservable(): Observable<T> {
+    return RxJava2Adapter.fluxToFlowable(this).toObservable()
+}
+
+/**
+ * Wraps an RxJava Maybe into a Mono instance.
+ * @param <T> the value type
+ * @return the new Mono instance
+ */
+fun <T> Maybe<T>.toMono(): Mono<T> {
+    return RxJava2Adapter.maybeToMono(this)
+}
+
+/**
+ * WRaps Mono instance into an RxJava Maybe.
+ * @param <T> the value type
+ * @return the new Maybe instance
+ */
+fun <T> Mono<T>.toMaybe(): Maybe<T> {
+    return RxJava2Adapter.monoToMaybe(this)
+}

--- a/reactor-adapter/src/test/kotlin/reactor/adapter/rxjava/RxJava2AdapterExtTest.kt
+++ b/reactor-adapter/src/test/kotlin/reactor/adapter/rxjava/RxJava2AdapterExtTest.kt
@@ -1,0 +1,153 @@
+package reactor.adapter.rxjava
+
+import io.reactivex.Completable
+import io.reactivex.Flowable
+import io.reactivex.Maybe
+import io.reactivex.Observable
+import io.reactivex.Single
+import org.junit.Test
+import reactor.core.Fuseable
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.test.test
+import java.util.*
+
+
+class RxJava2AdapterExtTest {
+
+    @Test
+    fun `Flowable to Flux`() {
+        Flowable.range(1, 10)
+            .toFlux()
+            .test()
+            .expectFusion()
+            .expectNext(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+            .expectComplete()
+            .verify()
+    }
+
+    @Test
+    fun `Flux to Flowable`() {
+        Flux.range(1, 10)
+            .toFlowable()
+            .test()
+            .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+            .assertComplete()
+    }
+
+    @Test
+    fun `Mono to Flowable`() {
+        Mono.just(1)
+            .toFlowable()
+            .test()
+            .assertValues(1)
+            .assertNoErrors()
+            .assertComplete()
+    }
+
+    @Test
+    fun `Mono to Completable`() {
+        Mono.empty<Any>()
+            .toCompletable()
+            .test()
+            .assertNoValues()
+            .assertNoErrors()
+            .assertComplete()
+    }
+
+    @Test
+    fun `Completable to Mono`() {
+        Completable.complete()
+            .toMono()
+            .test()
+            .expectComplete()
+            .verify()
+    }
+
+    @Test
+    fun `Mono to Single`() {
+        Mono.just(1)
+            .toSingle()
+            .test()
+            .assertValues(1)
+            .assertNoErrors()
+            .assertComplete()
+    }
+
+    @Test
+    fun `Empty Mono to Single`() {
+        Mono.empty<Int>()
+            .toSingle()
+            .test()
+            .assertNoValues()
+            .assertError(NoSuchElementException::class.java)
+            .assertNotComplete()
+    }
+
+    @Test
+    fun `Single to Mono`() {
+        Single.just(1)
+            .toMono()
+            .test()
+            .expectFusion(Fuseable.ANY, Fuseable.ASYNC)
+            .expectNext(1)
+            .expectComplete()
+            .verify()
+    }
+
+    @Test
+    fun `Observable to Flux`() {
+        Observable.range(1, 10)
+            .toFlux()
+            .test()
+            .expectFusion()
+            .expectNext(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+            .expectComplete()
+            .verify()
+    }
+
+    @Test
+    fun `Flux to Observable`() {
+        Flux.range(1, 10)
+            .toObservable()
+            .test()
+            .assertValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+            .assertNoErrors()
+            .assertComplete()
+    }
+
+    @Test
+    fun `Maybe to Mono`() {
+        Maybe.just(1)
+            .toMono()
+            .test()
+            .expectNext(1)
+            .expectComplete()
+            .verify()
+    }
+
+    @Test
+    fun `Empty Maybe to Mono`() {
+        Maybe.empty<Void>()
+            .toMono()
+            .test()
+            .expectComplete()
+            .verify()
+    }
+
+    @Test
+    fun `Mono to Maybe`() {
+        Mono.just(1)
+            .toMaybe()
+            .test()
+            .assertResult(1)
+    }
+
+    @Test
+    fun `Empty Mono to Maybe`() {
+        Mono.empty<Any>()
+            .toMaybe()
+            .test()
+            .assertResult()
+    }
+}

--- a/reactor-adapter/src/test/kotlin/reactor/adapter/rxjava/RxJava2AdapterExtTest.kt
+++ b/reactor-adapter/src/test/kotlin/reactor/adapter/rxjava/RxJava2AdapterExtTest.kt
@@ -9,7 +9,7 @@ import org.junit.Test
 import reactor.core.Fuseable
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
-import reactor.test.test
+import reactor.kotlin.test.test
 import java.util.*
 
 
@@ -18,8 +18,8 @@ class RxJava2AdapterExtTest {
     @Test
     fun `Flowable to Flux`() {
         Flowable.range(1, 10)
-            .toFlux()
-            .test()
+                .toFlux()
+                .test()
             .expectFusion()
             .expectNext(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
             .expectComplete()

--- a/reactor-extra/src/main/kotlin/reactor/bool/BooleanMonoExtensions.kt
+++ b/reactor-extra/src/main/kotlin/reactor/bool/BooleanMonoExtensions.kt
@@ -9,6 +9,8 @@ import reactor.core.publisher.Mono
  * @author Simon Baslé
  * @since 3.2.0
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("not()", "reactor.kotlin.extra.bool.not"))
 operator fun Mono<Boolean>.not(): Mono<Boolean> = BooleanUtils.not(this)
 
 /**
@@ -17,6 +19,8 @@ operator fun Mono<Boolean>.not(): Mono<Boolean> = BooleanUtils.not(this)
  * @author Simon Baslé
  * @since 3.2.0
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("logicalAnd(rightHand)", "reactor.kotlin.extra.bool.logicalHand"))
 fun Mono<Boolean>.logicalAnd(rightHand: Mono<Boolean>): Mono<Boolean> = BooleanUtils.and(this, rightHand)
 
 /**
@@ -25,6 +29,8 @@ fun Mono<Boolean>.logicalAnd(rightHand: Mono<Boolean>): Mono<Boolean> = BooleanU
  * @author Simon Baslé
  * @since 3.2.0
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("logicalNAnd(rightHand)", "reactor.kotlin.extra.bool.logicalNAnd"))
 fun Mono<Boolean>.logicalNAnd(rightHand: Mono<Boolean>): Mono<Boolean> = BooleanUtils.nand(this, rightHand)
 
 /**
@@ -33,6 +39,8 @@ fun Mono<Boolean>.logicalNAnd(rightHand: Mono<Boolean>): Mono<Boolean> = Boolean
  * @author Simon Baslé
  * @since 3.2.0
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("logicalOr()", "reactor.kotlin.extra.bool.logicalOr"))
 fun Mono<Boolean>.logicalOr(rightHand: Mono<Boolean>): Mono<Boolean> = BooleanUtils.or(this, rightHand)
 
 /**
@@ -41,6 +49,8 @@ fun Mono<Boolean>.logicalOr(rightHand: Mono<Boolean>): Mono<Boolean> = BooleanUt
  * @author Simon Baslé
  * @since 3.2.0
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("logicalNOr()", "reactor.kotlin.extra.bool.logicalNOr"))
 fun Mono<Boolean>.logicalNOr(rightHand: Mono<Boolean>): Mono<Boolean> = BooleanUtils.nor(this, rightHand)
 
 /**
@@ -49,4 +59,6 @@ fun Mono<Boolean>.logicalNOr(rightHand: Mono<Boolean>): Mono<Boolean> = BooleanU
  * @author Simon Baslé
  * @since 3.2.0
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("logicalXOr()", "reactor.kotlin.extra.bool.logicalXOr"))
 fun Mono<Boolean>.logicalXOr(rightHand: Mono<Boolean>): Mono<Boolean> = BooleanUtils.xor(this, rightHand)

--- a/reactor-extra/src/main/kotlin/reactor/bool/BooleanMonoExtensions.kt
+++ b/reactor-extra/src/main/kotlin/reactor/bool/BooleanMonoExtensions.kt
@@ -1,0 +1,52 @@
+package reactor.bool
+
+import reactor.core.publisher.Mono
+
+/**
+ * Extension to logically revert a [Boolean] [Mono]. It can also be
+ * applied as a ! operator.
+ *
+ * @author Simon Baslé
+ * @since 3.2.0
+ */
+operator fun Mono<Boolean>.not(): Mono<Boolean> = BooleanUtils.not(this)
+
+/**
+ * Extension to logically combine two [Boolean] [Mono] with the AND operator.
+ *
+ * @author Simon Baslé
+ * @since 3.2.0
+ */
+fun Mono<Boolean>.logicalAnd(rightHand: Mono<Boolean>): Mono<Boolean> = BooleanUtils.and(this, rightHand)
+
+/**
+ * Extension to logically combine two [Boolean] [Mono] with the Not-AND (NAND) operator.
+ *
+ * @author Simon Baslé
+ * @since 3.2.0
+ */
+fun Mono<Boolean>.logicalNAnd(rightHand: Mono<Boolean>): Mono<Boolean> = BooleanUtils.nand(this, rightHand)
+
+/**
+ * Extension to logically combine two [Boolean] [Mono] with the OR operator.
+ *
+ * @author Simon Baslé
+ * @since 3.2.0
+ */
+fun Mono<Boolean>.logicalOr(rightHand: Mono<Boolean>): Mono<Boolean> = BooleanUtils.or(this, rightHand)
+
+/**
+ * Extension to logically combine two [Boolean] [Mono] with the Not-OR (NOR) operator.
+ *
+ * @author Simon Baslé
+ * @since 3.2.0
+ */
+fun Mono<Boolean>.logicalNOr(rightHand: Mono<Boolean>): Mono<Boolean> = BooleanUtils.nor(this, rightHand)
+
+/**
+ * Extension to logically combine two [Boolean] [Mono] with the exclusive-OR (XOR) operator.
+ *
+ * @author Simon Baslé
+ * @since 3.2.0
+ */
+fun Mono<Boolean>.logicalXOr(rightHand: Mono<Boolean>): Mono<Boolean> = BooleanUtils.xor(this, rightHand)

--- a/reactor-extra/src/main/kotlin/reactor/math/MathFluxExtensions.kt
+++ b/reactor-extra/src/main/kotlin/reactor/math/MathFluxExtensions.kt
@@ -1,0 +1,145 @@
+package reactor.math
+
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import java.util.function.Function
+
+
+/**
+ * Extension to compute the [Long] sum of all values emitted by a [Flux] of [Number]
+ * and return it as a [Mono] of [Long].
+ *
+ * Note that summing decimal numbers with this method loses precision, see [sumDouble].
+ *
+ * @author Simon Baslé
+ * @since 3.1.1
+ */
+fun <T: Number> Flux<T>.sum(): Mono<Long> = MathFlux.sumLong(this)
+
+/**
+ * Extension to compute the [Double] sum of all values emitted by a [Flux] of [Number]
+ * and return it as a [Mono] of [Double].
+ *
+ * Note that since Double are more precise, some seemingly rounded Floats (e.g. 1.6f)
+ * may convert to Doubles with more decimals (eg. 1.600000023841858), producing sometimes
+ * unexpected sums.
+ *
+ * @author Simon Baslé
+ * @since 3.1.1
+ */
+fun <T: Number> Flux<T>.sumDouble(): Mono<Double> = MathFlux.sumDouble(this)
+/**
+ * Extension to compute the [Double] average of all values emitted by a [Flux] of [Number]
+ * and return it as a [Mono] of [Double].
+ *
+ * Note that since Double are more precise, some seemingly rounded Floats (e.g. 1.6f)
+ * may convert to Doubles with more decimals (eg. 1.600000023841858), producing sometimes
+ * unexpected averages.
+ *
+ * @author Simon Baslé
+ * @since 3.1.1
+ */
+fun <T: Number> Flux<T>.average(): Mono<Double> = MathFlux.averageDouble(this)
+
+//min and max that work on any comparable
+/**
+ * Extension to find the lowest value in a [Flux] of [Comparable] values and return it
+ * as a [Mono] of [T].
+ *
+ * @author Simon Baslé
+ * @since 3.1.1
+ */
+fun <T: Comparable<T>> Flux<T>.min(): Mono<T> = MathFlux.min(this)
+/**
+ * Extension to find the highest value in a [Flux] of [Comparable] values and return it
+ * as a [Mono] of [T].
+ *
+ * @author Simon Baslé
+ * @since 3.1.1
+ */
+fun <T: Comparable<T>> Flux<T>.max(): Mono<T> = MathFlux.max(this)
+
+//sum/sumDouble/average lambda versions where a converter is provided
+/**
+ * Extension to map arbitrary values in a [Flux] to [Number]s and return the sum of these
+ * Numbers as a [Mono] of [Long].
+ *
+ * [Float] and [Double] are rounded to [Long] by [MathFlux], using Java standard
+ * conversions.
+ *
+ * @param mapper a lambda converting values to [Number]
+ * @author Simon Baslé
+ * @since 3.1.1
+ */
+fun <T> Flux<T>.sum(mapper: (T) -> Number): Mono<Long>
+        = MathFlux.sumLong(this, Function(mapper))
+/**
+ * Extension to map arbitrary values in a [Flux] to [Number]s and return the sum of these
+ * Numbers as a [Mono] of [Double], thus avoiding rounding
+ * down to zero decimal places.
+ *
+ * Note that since [Double] are more precise than [Float], some seemingly rounded Floats
+ * (e.g. 1.6f) may convert to Doubles with more decimals (eg. 1.600000023841858),
+ * producing sometimes unexpected results.
+ *
+ * @param mapper a lambda converting values to [Number]
+ * @author Simon Baslé
+ * @since 3.1.1
+ */
+fun <T> Flux<T>.sumDouble(mapper: (T) -> Number): Mono<Double>
+        = MathFlux.sumDouble(this, Function(mapper))
+/**
+ * Extension to map arbitrary values in a [Flux] to [Number]s and return the average of
+ * these Numbers as a [Mono] of [Double].
+ *
+ * Note that since [Double] are more precise than [Float], some seemingly rounded Floats
+ * (e.g. 1.6f) may convert to Doubles with more decimals (eg. 1.600000023841858),
+ * producing sometimes unexpected results.
+ *
+ * @param mapper a lambda converting values to [Number]
+ * @author Simon Baslé
+ * @since 3.1.1
+ */
+fun <T> Flux<T>.average(mapper: (T) -> Number): Mono<Double>
+        = MathFlux.averageDouble(this, Function(mapper))
+
+
+//min/max lambda versions where a comparator or equivalent function is provided
+/**
+ * Extension to find the lowest value in a [Flux] and return it as a [Mono]. The lowest
+ * value is defined by comparisons made using a provided [Comparator].
+ *
+ * @param comp The [Comparator] to use
+ * @author Simon Baslé
+ * @since 3.1.1
+ */
+fun <T> Flux<T>.min(comp: Comparator<T>): Mono<T> = MathFlux.min(this, comp)
+/**
+ * Extension to find the lowest value in a [Flux] and return it as a [Mono]. The lowest
+ * value is defined by comparisons made using a provided function that behaves like a
+ * [Comparator].
+ *
+ * @param comp The comparison function to use (similar to a [Comparator])
+ * @author Simon Baslé
+ * @since 3.1.1
+ */
+fun <T> Flux<T>.min(comp: (T, T) -> Int): Mono<T> = MathFlux.min(this, Comparator(comp))
+/**
+ * Extension to find the highest value in a [Flux] and return it as a [Mono]. The highest
+ * value is defined by comparisons made using a provided [Comparator].
+ *
+ * @param comp The [Comparator] to use
+ * @author Simon Baslé
+ * @since 3.1.1
+ */
+fun <T> Flux<T>.max(comp: Comparator<T>): Mono<T> = MathFlux.max(this, comp)
+/**
+ * Extension to find the highest value in a [Flux] and return it as a [Mono]. The highest
+ * value is defined by comparisons made using a provided function that behaves like a
+ * [Comparator].
+ *
+ * @param comp The comparison function to use (similar to a [Comparator])
+ * @author Simon Baslé
+ * @since 3.1.1
+ */
+fun <T> Flux<T>.max(comp: (T, T) -> Int): Mono<T> = MathFlux.max(this, Comparator(comp))

--- a/reactor-extra/src/main/kotlin/reactor/math/MathFluxExtensions.kt
+++ b/reactor-extra/src/main/kotlin/reactor/math/MathFluxExtensions.kt
@@ -14,6 +14,8 @@ import java.util.function.Function
  * @author Simon Baslé
  * @since 3.1.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("sum()", "reactor.kotlin.extra.math.sum"))
 fun <T: Number> Flux<T>.sum(): Mono<Long> = MathFlux.sumLong(this)
 
 /**
@@ -27,7 +29,10 @@ fun <T: Number> Flux<T>.sum(): Mono<Long> = MathFlux.sumLong(this)
  * @author Simon Baslé
  * @since 3.1.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("sumDouble()", "reactor.kotlin.extra.math.sumDouble"))
 fun <T: Number> Flux<T>.sumDouble(): Mono<Double> = MathFlux.sumDouble(this)
+
 /**
  * Extension to compute the [Double] average of all values emitted by a [Flux] of [Number]
  * and return it as a [Mono] of [Double].
@@ -39,6 +44,8 @@ fun <T: Number> Flux<T>.sumDouble(): Mono<Double> = MathFlux.sumDouble(this)
  * @author Simon Baslé
  * @since 3.1.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("average()", "reactor.kotlin.extra.math.average"))
 fun <T: Number> Flux<T>.average(): Mono<Double> = MathFlux.averageDouble(this)
 
 //min and max that work on any comparable
@@ -49,7 +56,10 @@ fun <T: Number> Flux<T>.average(): Mono<Double> = MathFlux.averageDouble(this)
  * @author Simon Baslé
  * @since 3.1.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("min()", "reactor.kotlin.extra.math.min"))
 fun <T: Comparable<T>> Flux<T>.min(): Mono<T> = MathFlux.min(this)
+
 /**
  * Extension to find the highest value in a [Flux] of [Comparable] values and return it
  * as a [Mono] of [T].
@@ -57,6 +67,8 @@ fun <T: Comparable<T>> Flux<T>.min(): Mono<T> = MathFlux.min(this)
  * @author Simon Baslé
  * @since 3.1.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("max()", "reactor.kotlin.extra.math.max"))
 fun <T: Comparable<T>> Flux<T>.max(): Mono<T> = MathFlux.max(this)
 
 //sum/sumDouble/average lambda versions where a converter is provided
@@ -71,8 +83,11 @@ fun <T: Comparable<T>> Flux<T>.max(): Mono<T> = MathFlux.max(this)
  * @author Simon Baslé
  * @since 3.1.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("sum(mapper)", "reactor.kotlin.extra.math.sum"))
 fun <T> Flux<T>.sum(mapper: (T) -> Number): Mono<Long>
         = MathFlux.sumLong(this, Function(mapper))
+
 /**
  * Extension to map arbitrary values in a [Flux] to [Number]s and return the sum of these
  * Numbers as a [Mono] of [Double], thus avoiding rounding
@@ -86,6 +101,9 @@ fun <T> Flux<T>.sum(mapper: (T) -> Number): Mono<Long>
  * @author Simon Baslé
  * @since 3.1.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("sumDouble(mapper)", "reactor.kotlin.extra.math.sumDouble"))
+
 fun <T> Flux<T>.sumDouble(mapper: (T) -> Number): Mono<Double>
         = MathFlux.sumDouble(this, Function(mapper))
 /**
@@ -100,6 +118,8 @@ fun <T> Flux<T>.sumDouble(mapper: (T) -> Number): Mono<Double>
  * @author Simon Baslé
  * @since 3.1.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("average(mapper)", "reactor.kotlin.extra.math.average"))
 fun <T> Flux<T>.average(mapper: (T) -> Number): Mono<Double>
         = MathFlux.averageDouble(this, Function(mapper))
 
@@ -113,7 +133,10 @@ fun <T> Flux<T>.average(mapper: (T) -> Number): Mono<Double>
  * @author Simon Baslé
  * @since 3.1.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("min(comp)", "reactor.kotlin.extra.math.min"))
 fun <T> Flux<T>.min(comp: Comparator<T>): Mono<T> = MathFlux.min(this, comp)
+
 /**
  * Extension to find the lowest value in a [Flux] and return it as a [Mono]. The lowest
  * value is defined by comparisons made using a provided function that behaves like a
@@ -123,7 +146,10 @@ fun <T> Flux<T>.min(comp: Comparator<T>): Mono<T> = MathFlux.min(this, comp)
  * @author Simon Baslé
  * @since 3.1.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("min(comp)", "reactor.kotlin.extra.math.min"))
 fun <T> Flux<T>.min(comp: (T, T) -> Int): Mono<T> = MathFlux.min(this, Comparator(comp))
+
 /**
  * Extension to find the highest value in a [Flux] and return it as a [Mono]. The highest
  * value is defined by comparisons made using a provided [Comparator].
@@ -132,7 +158,10 @@ fun <T> Flux<T>.min(comp: (T, T) -> Int): Mono<T> = MathFlux.min(this, Comparato
  * @author Simon Baslé
  * @since 3.1.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("max(comp)", "reactor.kotlin.extra.math.max"))
 fun <T> Flux<T>.max(comp: Comparator<T>): Mono<T> = MathFlux.max(this, comp)
+
 /**
  * Extension to find the highest value in a [Flux] and return it as a [Mono]. The highest
  * value is defined by comparisons made using a provided function that behaves like a
@@ -142,4 +171,6 @@ fun <T> Flux<T>.max(comp: Comparator<T>): Mono<T> = MathFlux.max(this, comp)
  * @author Simon Baslé
  * @since 3.1.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("max(comp)", "reactor.kotlin.extra.math.max"))
 fun <T> Flux<T>.max(comp: (T, T) -> Int): Mono<T> = MathFlux.max(this, Comparator(comp))

--- a/reactor-extra/src/main/kotlin/reactor/retry/RepeatExtensions.kt
+++ b/reactor-extra/src/main/kotlin/reactor/retry/RepeatExtensions.kt
@@ -1,0 +1,109 @@
+package reactor.retry
+
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import java.time.Duration
+import java.util.function.Consumer
+
+/**
+ * Extension to add a [Flux.repeat] variant to [Flux] that uses an exponential backoff,
+ * as enabled by reactor-extra's [Repeat] builder.
+ *
+ * @param times the maximum number of retry attempts
+ * @param first the initial delay in retrying
+ * @param max the optional upper limit the delay can reach after subsequent backoffs
+ * @param jitter optional flag to activate random jitter in the backoffs
+ * @param doOnRepeat optional [Consumer]-like lambda that will receive a [RepeatContext]
+ *   each time an attempt is made.
+ *
+ * @author Simon Baslé
+ * @since 3.1.1
+ */
+fun <T> Flux<T>.repeatExponentialBackoff(times: Long, first: Duration, max: Duration? = null,
+                                         jitter: Boolean = false,
+                                         doOnRepeat: ((RepeatContext<T>) -> Unit)? = null): Flux<T> {
+    val repeat = Repeat.times<T>(times)
+            .exponentialBackoff(first, max)
+            .jitter(if (jitter) Jitter.random() else Jitter.noJitter())
+
+    return if (doOnRepeat == null)
+        repeat.apply(this)
+    else
+        repeat.doOnRepeat(doOnRepeat).apply(this)
+}
+
+/**
+ * Extension to add a [Flux.repeat] variant to [Flux] that uses a randomized backoff,
+ * as enabled by reactor-extra's [Repeat] builder.
+ *
+ * @param times the maximum number of retry attempts
+ * @param first the initial delay in retrying
+ * @param max the optional upper limit the delay can reach after subsequent backoffs
+ * @param doOnRepeat optional [Consumer]-like lambda that will receive a [RepeatContext]
+ *   each time an attempt is made.
+ *
+ * @author Simon Baslé
+ * @since 3.1.1
+ */
+fun <T> Flux<T>.repeatRandomBackoff(times: Long, first: Duration, max: Duration? = null,
+                                    doOnRepeat: ((RepeatContext<T>) -> Unit)? = null): Flux<T> {
+    val repeat = Repeat.times<T>(times)
+            .randomBackoff(first, max)
+
+    return if (doOnRepeat == null)
+        repeat.apply(this)
+    else
+        repeat.doOnRepeat(doOnRepeat).apply(this)
+}
+
+
+/**
+ * Extension to add a [Mono.repeat] variant to [Mono] that uses an exponential backoff,
+ * as enabled by reactor-extra's [Repeat] builder.
+ *
+ * @param times the maximum number of retry attempts
+ * @param first the initial delay in retrying
+ * @param max the optional upper limit the delay can reach after subsequent backoffs
+ * @param jitter optional flag to activate random jitter in the backoffs
+ * @param doOnRepeat optional [Consumer]-like lambda that will receive a [RepeatContext]
+ *   each time an attempt is made.
+ *
+ * @author Simon Baslé
+ * @since 3.1.1
+ */
+fun <T> Mono<T>.repeatExponentialBackoff(times: Long, first: Duration, max: Duration? = null,
+                                         jitter: Boolean = false,
+                                         doOnRepeat: ((RepeatContext<T>) -> Unit)? = null): Flux<T> {
+    val repeat = Repeat.times<T>(times)
+            .exponentialBackoff(first, max)
+            .jitter(if (jitter) Jitter.random() else Jitter.noJitter())
+
+    return if (doOnRepeat == null)
+        repeat.apply(this)
+    else
+        repeat.doOnRepeat(doOnRepeat).apply(this)
+}
+
+/**
+ * Extension to add a [Mono.repeat] variant to [Mono] that uses a randomized backoff,
+ * as enabled by reactor-extra's [Repeat] builder.
+ *
+ * @param times the maximum number of retry attempts
+ * @param first the initial delay in retrying
+ * @param max the optional upper limit the delay can reach after subsequent backoffs
+ * @param doOnRepeat optional [Consumer]-like lambda that will receive a [RepeatContext]
+ *   each time an attempt is made.
+ *
+ * @author Simon Baslé
+ * @since 3.1.1
+ */
+fun <T> Mono<T>.repeatRandomBackoff(times: Long, first: Duration, max: Duration? = null,
+                                    doOnRepeat: ((RepeatContext<T>) -> Unit)? = null): Flux<T> {
+    val repeat = Repeat.times<T>(times)
+            .randomBackoff(first, max)
+
+    return if (doOnRepeat == null)
+        repeat.apply(this)
+    else
+        repeat.doOnRepeat(doOnRepeat).apply(this)
+}

--- a/reactor-extra/src/main/kotlin/reactor/retry/RepeatExtensions.kt
+++ b/reactor-extra/src/main/kotlin/reactor/retry/RepeatExtensions.kt
@@ -19,6 +19,8 @@ import java.util.function.Consumer
  * @author Simon Baslé
  * @since 3.1.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("repeatExponentialBackoff(times, first, max, jitter, doOnRepeat)", "reactor.kotlin.extra.retry.repeatExponentialBackoff"))
 fun <T> Flux<T>.repeatExponentialBackoff(times: Long, first: Duration, max: Duration? = null,
                                          jitter: Boolean = false,
                                          doOnRepeat: ((RepeatContext<T>) -> Unit)? = null): Flux<T> {
@@ -45,6 +47,8 @@ fun <T> Flux<T>.repeatExponentialBackoff(times: Long, first: Duration, max: Dura
  * @author Simon Baslé
  * @since 3.1.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("repeatRandomBackoff(times, first, max, doOnRepeat)", "reactor.kotlin.extra.retry.repeatRandomBackoff"))
 fun <T> Flux<T>.repeatRandomBackoff(times: Long, first: Duration, max: Duration? = null,
                                     doOnRepeat: ((RepeatContext<T>) -> Unit)? = null): Flux<T> {
     val repeat = Repeat.times<T>(times)
@@ -71,6 +75,8 @@ fun <T> Flux<T>.repeatRandomBackoff(times: Long, first: Duration, max: Duration?
  * @author Simon Baslé
  * @since 3.1.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("repeatExponentialBackoff(times, first, max, jitter, doOnRepeat)", "reactor.kotlin.extra.retry.repeatExponentialBackoff"))
 fun <T> Mono<T>.repeatExponentialBackoff(times: Long, first: Duration, max: Duration? = null,
                                          jitter: Boolean = false,
                                          doOnRepeat: ((RepeatContext<T>) -> Unit)? = null): Flux<T> {
@@ -97,6 +103,8 @@ fun <T> Mono<T>.repeatExponentialBackoff(times: Long, first: Duration, max: Dura
  * @author Simon Baslé
  * @since 3.1.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("repeatRandomBackoff(times, first, max, doOnRepeat)", "reactor.kotlin.extra.retry.repeatRandomBackoff"))
 fun <T> Mono<T>.repeatRandomBackoff(times: Long, first: Duration, max: Duration? = null,
                                     doOnRepeat: ((RepeatContext<T>) -> Unit)? = null): Flux<T> {
     val repeat = Repeat.times<T>(times)

--- a/reactor-extra/src/main/kotlin/reactor/retry/RetryExtensions.kt
+++ b/reactor-extra/src/main/kotlin/reactor/retry/RetryExtensions.kt
@@ -19,6 +19,8 @@ import java.util.function.Consumer
  * @author Simon Baslé
  * @since 3.1.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("retryExponentialBackoff(times, first, max, jitter, doOnRetry)", "reactor.kotlin.extra.retry.retryExponentialBackoff"))
 fun <T> Flux<T>.retryExponentialBackoff(times: Long, first: Duration, max: Duration? = null,
                                         jitter: Boolean = false,
                                         doOnRetry: ((RetryContext<T>) -> Unit)? = null): Flux<T> {
@@ -46,6 +48,8 @@ fun <T> Flux<T>.retryExponentialBackoff(times: Long, first: Duration, max: Durat
  * @author Simon Baslé
  * @since 3.1.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("retryRandomBackoff(times, first, max, doOnRetry)", "reactor.kotlin.extra.retry.retryRandomBackoff"))
 fun <T> Flux<T>.retryRandomBackoff(times: Long, first: Duration, max: Duration? = null,
                                    doOnRetry: ((RetryContext<T>) -> Unit)? = null): Flux<T> {
     val retry = Retry.any<T>()
@@ -72,6 +76,8 @@ fun <T> Flux<T>.retryRandomBackoff(times: Long, first: Duration, max: Duration? 
  * @author Simon Baslé
  * @since 3.1.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("retryExponentialBackoff(times, first, max, jitter, doOnRetry)", "reactor.kotlin.extra.retry.retryExponentialBackoff"))
 fun <T> Mono<T>.retryExponentialBackoff(times: Long, first: Duration, max: Duration? = null,
                                         jitter: Boolean = false,
                                         doOnRetry: ((RetryContext<T>) -> Unit)? = null): Mono<T> {
@@ -99,6 +105,8 @@ fun <T> Mono<T>.retryExponentialBackoff(times: Long, first: Duration, max: Durat
  * @author Simon Baslé
  * @since 3.1.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("retryRandomBackoff(times, first, max, doOnRetry)", "reactor.kotlin.extra.retry.retryRandomBackoff"))
 fun <T> Mono<T>.retryRandomBackoff(times: Long, first: Duration, max: Duration? = null,
                                    doOnRetry: ((RetryContext<T>) -> Unit)? = null): Mono<T> {
     val retry = Retry.any<T>()

--- a/reactor-extra/src/main/kotlin/reactor/retry/RetryExtensions.kt
+++ b/reactor-extra/src/main/kotlin/reactor/retry/RetryExtensions.kt
@@ -1,0 +1,113 @@
+package reactor.retry
+
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import java.time.Duration
+import java.util.function.Consumer
+
+/**
+ * Extension to add a [Flux.retry] variant to [Flux] that uses an exponential backoff,
+ * as enabled by reactor-extra's [Retry] builder.
+ *
+ * @param times the maximum number of retry attempts
+ * @param first the initial delay in retrying
+ * @param max the optional upper limit the delay can reach after subsequent backoffs
+ * @param jitter optional flag to activate random jitter in the backoffs
+ * @param doOnRetry optional [Consumer]-like lambda that will receive a [RetryContext]
+ *   each time an attempt is made.
+ *
+ * @author Simon Baslé
+ * @since 3.1.1
+ */
+fun <T> Flux<T>.retryExponentialBackoff(times: Long, first: Duration, max: Duration? = null,
+                                        jitter: Boolean = false,
+                                        doOnRetry: ((RetryContext<T>) -> Unit)? = null): Flux<T> {
+    val retry = Retry.any<T>()
+            .retryMax(times)
+            .exponentialBackoff(first, max)
+            .jitter(if (jitter) Jitter.random() else Jitter.noJitter())
+
+    return if (doOnRetry == null)
+        retry.apply(this)
+    else
+        retry.doOnRetry(doOnRetry).apply(this)
+}
+
+/**
+ * Extension to add a [Flux.retry] variant to [Flux] that uses a random backoff,
+ * as enabled by reactor-extra's [Retry] builder.
+ *
+ * @param times the maximum number of retry attempts
+ * @param first the initial delay in retrying
+ * @param max the optional upper limit the delay can reach after subsequent backoffs
+ * @param doOnRetry optional [Consumer]-like lambda that will receive a [RetryContext]
+ *   each time an attempt is made.
+ *
+ * @author Simon Baslé
+ * @since 3.1.1
+ */
+fun <T> Flux<T>.retryRandomBackoff(times: Long, first: Duration, max: Duration? = null,
+                                   doOnRetry: ((RetryContext<T>) -> Unit)? = null): Flux<T> {
+    val retry = Retry.any<T>()
+            .retryMax(times)
+            .randomBackoff(first, max)
+
+    return if (doOnRetry == null)
+        retry.apply(this)
+    else
+        retry.doOnRetry(doOnRetry).apply(this)
+}
+
+/**
+ * Extension to add a [Mono.retry] variant to [Mono] that uses an exponential backoff,
+ * as enabled by reactor-extra's [Retry] builder.
+ *
+ * @param times the maximum number of retry attempts
+ * @param first the initial delay in retrying
+ * @param max the optional upper limit the delay can reach after subsequent backoffs
+ * @param jitter optional flag to activate random jitter in the backoffs
+ * @param doOnRetry optional [Consumer]-like lambda that will receive a [RetryContext]
+ *   each time an attempt is made.
+ *
+ * @author Simon Baslé
+ * @since 3.1.1
+ */
+fun <T> Mono<T>.retryExponentialBackoff(times: Long, first: Duration, max: Duration? = null,
+                                        jitter: Boolean = false,
+                                        doOnRetry: ((RetryContext<T>) -> Unit)? = null): Mono<T> {
+    val retry = Retry.any<T>()
+            .retryMax(times)
+            .exponentialBackoff(first, max)
+            .jitter(if (jitter) Jitter.random() else Jitter.noJitter())
+
+    return if (doOnRetry == null)
+        this.retryWhen(retry)
+    else
+        this.retryWhen(retry.doOnRetry(doOnRetry))
+}
+
+/**
+ * Extension to add a [Mono.retry] variant to [Mono] that uses a random backoff,
+ * as enabled by reactor-extra's [Retry] builder.
+ *
+ * @param times the maximum number of retry attempts
+ * @param first the initial delay in retrying
+ * @param max the optional upper limit the delay can reach after subsequent backoffs
+ * @param doOnRetry optional [Consumer]-like lambda that will receive a [RetryContext]
+ *   each time an attempt is made.
+ *
+ * @author Simon Baslé
+ * @since 3.1.1
+ */
+fun <T> Mono<T>.retryRandomBackoff(times: Long, first: Duration, max: Duration? = null,
+                                   doOnRetry: ((RetryContext<T>) -> Unit)? = null): Mono<T> {
+    val retry = Retry.any<T>()
+            .retryMax(times)
+            .randomBackoff(first, max)
+
+    return if (doOnRetry == null)
+        this.retryWhen(retry)
+    else
+        this.retryWhen(retry.doOnRetry(doOnRetry))
+}
+

--- a/reactor-extra/src/main/kotlin/reactor/swing/SwtSchedulerExtensions.kt
+++ b/reactor-extra/src/main/kotlin/reactor/swing/SwtSchedulerExtensions.kt
@@ -9,4 +9,6 @@ import reactor.core.scheduler.Scheduler
  * @author Simon Baslé
  * @since 3.1.1
  */
+@Deprecated("To be removed in 3.3.0.RELEASE, replaced by module reactor-kotlin-extensions",
+        ReplaceWith("toScheduler()", "reactor.kotlin.extra.swing.toScheduler"))
 fun Display.toScheduler(): Scheduler = SwtScheduler.from(this)

--- a/reactor-extra/src/main/kotlin/reactor/swing/SwtSchedulerExtensions.kt
+++ b/reactor-extra/src/main/kotlin/reactor/swing/SwtSchedulerExtensions.kt
@@ -1,0 +1,12 @@
+package reactor.swing
+
+import org.eclipse.swt.widgets.Display
+import reactor.core.scheduler.Scheduler
+
+/**
+ * Extension to convert a SWT Display to a [Scheduler].
+ *
+ * @author Simon Baslé
+ * @since 3.1.1
+ */
+fun Display.toScheduler(): Scheduler = SwtScheduler.from(this)

--- a/reactor-extra/src/test/kotlin/reactor/bool/BooleanMonoExtensionsTests.kt
+++ b/reactor-extra/src/test/kotlin/reactor/bool/BooleanMonoExtensionsTests.kt
@@ -3,7 +3,7 @@ package reactor.bool
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import reactor.core.publisher.Mono
-import reactor.test.test
+import reactor.kotlin.test.test
 
 class BooleanMonoExtensionsTests {
 

--- a/reactor-extra/src/test/kotlin/reactor/bool/BooleanMonoExtensionsTests.kt
+++ b/reactor-extra/src/test/kotlin/reactor/bool/BooleanMonoExtensionsTests.kt
@@ -1,0 +1,95 @@
+package reactor.bool
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import reactor.core.publisher.Mono
+import reactor.test.test
+
+class BooleanMonoExtensionsTests {
+
+    private val mTrue: Mono<Boolean> = Mono.just(true)
+    private val mFalse: Mono<Boolean> = Mono.just(false)
+
+    private fun booleanTable(
+            op: (Mono<Boolean>, Mono<Boolean>) -> Mono<Boolean>,
+            expectedTrueTrue: Boolean,
+            expectedTrueFalse: Boolean,
+            expectedFalseTrue: Boolean,
+            expectedFalseFalse: Boolean) {
+
+        op.invoke(mTrue, mTrue).test()
+                .expectNext(expectedTrueTrue)
+                .`as`("(true, true)")
+                .verifyComplete()
+        op.invoke(mTrue, mFalse).test()
+                .expectNext(expectedTrueFalse)
+                .`as`("(true, false)")
+                .verifyComplete()
+        op.invoke(mFalse, mTrue).test()
+                .expectNext(expectedFalseTrue)
+                .`as`("(false, true)")
+                .verifyComplete()
+        op.invoke(mFalse, mFalse).test()
+                .expectNext(expectedFalseFalse)
+                .`as`("(false, false)")
+                .verifyComplete()
+    }
+
+    @Test
+    fun smokeTest() {
+        assertThat(mTrue.logicalAnd(mFalse).block()).`as`("true AND false").isFalse()
+        assertThat(mTrue.logicalOr(mFalse).block()).`as`("true OR false").isTrue()
+        assertThat(mTrue.logicalNAnd(mFalse).block()).`as`("true NAND false").isTrue()
+        assertThat(mTrue.logicalNOr(mFalse).block()).`as`("true NOR false").isFalse()
+        assertThat(mTrue.logicalXOr(mFalse).block()).`as`("true XOR false").isTrue()
+    }
+
+    @Test
+    fun logicalAnd() {
+        booleanTable(Mono<Boolean>::logicalAnd,
+                true, false,
+                false, false)
+    }
+
+    @Test
+    fun logicalOr() {
+        booleanTable(Mono<Boolean>::logicalOr,
+                true, true,
+                true, false)
+    }
+
+    @Test
+    fun logicalNand() {
+        booleanTable(Mono<Boolean>::logicalNAnd,
+                false, true,
+                true, true)
+    }
+
+    @Test
+    fun logicalNor() {
+        booleanTable(Mono<Boolean>::logicalNOr,
+                false, false,
+                false, true)
+    }
+
+    @Test
+    fun logicalXor() {
+        booleanTable(Mono<Boolean>::logicalXOr,
+                false, true,
+                true, false)
+    }
+
+    @Test
+    fun not() {
+        mTrue.not().test().expectNext(false).`as`("not(true)").verifyComplete()
+
+        mFalse.not().test().expectNext(true).`as`("not(false)").verifyComplete()
+    }
+
+    @Test
+    fun notWithOperator() {
+        (!mTrue).test().expectNext(false).`as`("!true").verifyComplete()
+
+        (!mFalse).test().expectNext(true).`as`("!false").verifyComplete()
+    }
+}

--- a/reactor-extra/src/test/kotlin/reactor/math/MathFluxExtensionsTests.kt
+++ b/reactor-extra/src/test/kotlin/reactor/math/MathFluxExtensionsTests.kt
@@ -2,8 +2,8 @@ package reactor.math
 
 import org.junit.Test
 import reactor.core.publisher.Flux
-import reactor.core.publisher.toFlux
-import reactor.test.test
+import reactor.kotlin.core.publisher.toFlux
+import reactor.kotlin.test.test
 
 /**
  * @author Simon Baslé

--- a/reactor-extra/src/test/kotlin/reactor/math/MathFluxExtensionsTests.kt
+++ b/reactor-extra/src/test/kotlin/reactor/math/MathFluxExtensionsTests.kt
@@ -1,0 +1,402 @@
+package reactor.math
+
+import org.junit.Test
+import reactor.core.publisher.Flux
+import reactor.core.publisher.toFlux
+import reactor.test.test
+
+/**
+ * @author Simon Baslé
+ */
+class MathFluxExtensionsTests {
+
+    data class User(val age: Int,val name: String)
+
+    companion object {
+        val userList = listOf(User(18, "bob"),
+                User(80, "grandpa"),
+                User(1, "baby"))
+
+        val comparator: Comparator<User> = Comparator({ u1: User, u2:User -> u1.age - u2.age})
+
+        val comparableList = listOf("AA", "A", "BB", "B", "AB")
+    }
+
+    //== sum ==
+    @Test
+    fun sumShorts() {
+        shortArrayOf(32_000, 8_000) //sum overflows a Short
+                .toFlux()
+                .sum()
+                .test()
+                .expectNext(40_000)
+                .verifyComplete()
+    }
+
+    @Test
+    fun sumInts() {
+        intArrayOf(2_000_000_000, 200_000_000) //sum overflows an Int
+                .toFlux()
+                .sum()
+                .test()
+                .expectNext(2_200_000_000)
+                .verifyComplete()
+    }
+
+    @Test
+    fun sumLongs() {
+        longArrayOf(3_000_000_000, 2_000_000_000)
+                .toFlux()
+                .sum()
+                .test()
+                .expectNext(5_000_000_000)
+                .verifyComplete()
+    }
+
+    @Test
+    fun sumFloatsPrecisionLoss() {
+        floatArrayOf(3.5f, 1.5f)
+                .toFlux()
+                .sum()
+                .test()
+                .expectNext(4)
+                .verifyComplete()
+    }
+
+    @Test
+    fun sumDoublesPrecisionLoss() {
+        doubleArrayOf(3.5, 1.5)
+                .toFlux()
+                .sum()
+                .test()
+                .expectNext(4)
+                .verifyComplete()
+    }
+
+    @Test
+    fun sumMapped() {
+        userList.toFlux()
+                .sum { it.age }
+                .test()
+                .expectNext(99)
+                .verifyComplete()
+    }
+
+    //== sumDouble ==
+    @Test
+    fun sumDoubleShorts() {
+        shortArrayOf(32_000, 8_000) //sum overflows a Short
+                .toFlux()
+                .sumDouble()
+                .test()
+                .expectNext(40_000.0)
+                .verifyComplete()
+    }
+
+    @Test
+    fun sumDoubleInts() {
+        intArrayOf(2_000_000_000, 200_000_000) //sum overflows an Int
+                .toFlux()
+                .sumDouble()
+                .test()
+                .expectNext(2_200_000_000.0)
+                .verifyComplete()
+    }
+
+    @Test
+    fun sumDoubleLongs() {
+        longArrayOf(3_000_000_000, 2_000_000_000)
+                .toFlux()
+                .sumDouble()
+                .test()
+                .expectNext(5_000_000_000.0)
+                .verifyComplete()
+    }
+
+    @Test
+    fun sumDoubleFloats() {
+        floatArrayOf(3.5f, 1.5f)
+                .toFlux()
+                .sumDouble()
+                .test()
+                .expectNext(5.0)
+                .verifyComplete()
+    }
+
+    @Test
+    fun sumDoubleDoubles() {
+        doubleArrayOf(3.5, 1.5)
+                .toFlux()
+                .sumDouble()
+                .test()
+                .expectNext(5.0)
+                .verifyComplete()
+    }
+
+    @Test
+    fun sumDoubleMapped() {
+        userList.toFlux()
+                .sumDouble { it.age }
+                .test()
+                .expectNext(99.0)
+                .verifyComplete()
+    }
+
+    //== average ==
+    @Test
+    fun averageShorts() {
+        shortArrayOf(10, 11)
+                .toFlux()
+                .average()
+                .test()
+                .expectNext(10.5)
+                .verifyComplete()
+    }
+
+    @Test
+    fun averageInts() {
+        intArrayOf(10, 11)
+                .toFlux()
+                .average()
+                .test()
+                .expectNext(10.5)
+                .verifyComplete()
+    }
+
+    @Test
+    fun averageLongs() {
+        longArrayOf(10, 11)
+                .toFlux()
+                .average()
+                .test()
+                .expectNext(10.5)
+                .verifyComplete()
+    }
+
+    @Test
+    fun averageFloats() {
+        floatArrayOf(10f, 11f)
+                .toFlux()
+                .average()
+                .test()
+                .expectNext(10.5)
+                .verifyComplete()
+    }
+
+    @Test
+    fun averageDoubles() {
+        doubleArrayOf(10.0, 11.0)
+                .toFlux()
+                .average()
+                .test()
+                .expectNext(10.5)
+                .verifyComplete()
+    }
+
+    @Test
+    fun averageMapped() {
+        userList.toFlux()
+                .average { it.age }
+                .test()
+                .expectNext(33.0)
+                .verifyComplete()
+    }
+
+    //== min ==
+    @Test
+    fun minShorts() {
+        shortArrayOf(12, 8, 16)
+                .toFlux()
+                .min()
+                .test()
+                .expectNext(8)
+                .verifyComplete()
+    }
+
+    @Test
+    fun minInts() {
+        intArrayOf(12, 8, 16)
+                .toFlux()
+                .min()
+                .test()
+                .expectNext(8)
+                .verifyComplete()
+    }
+
+    @Test
+    fun minLongs() {
+        longArrayOf(12, 8, 16)
+                .toFlux()
+                .min()
+                .test()
+                .expectNext(8)
+                .verifyComplete()
+    }
+
+    @Test
+    fun minFloats() {
+        floatArrayOf(12f, 8.1f, 16f, 8.2f)
+                .toFlux()
+                .min()
+                .test()
+                .expectNext(8.1f)
+                .verifyComplete()
+    }
+
+    @Test
+    fun minDoubles() {
+        doubleArrayOf(12.0, 8.1, 16.0, 8.2)
+                .toFlux()
+                .min()
+                .test()
+                .expectNext(8.1)
+                .verifyComplete()
+    }
+
+    @Test
+    fun minComparables() {
+        comparableList.toFlux()
+                .min()
+                .test()
+                .expectNext("A")
+                .verifyComplete()
+    }
+
+    @Test
+    fun minComparator() {
+        userList.toFlux()
+                .min(comparator)
+                .map { it.name }
+                .test()
+                .expectNext("baby")
+                .verifyComplete()
+    }
+
+    @Test
+    fun minComparatorLambdaInverted() {
+        userList.toFlux()
+                .min { a, b -> b.age - a.age }
+                .map { it.name }
+                .test()
+                .expectNext("grandpa")
+                .verifyComplete()
+    }
+
+    //== max ==
+    @Test
+    fun maxShorts() {
+        shortArrayOf(12, 8, 16)
+                .toFlux()
+                .max()
+                .test()
+                .expectNext(16)
+                .verifyComplete()
+    }
+
+    @Test
+    fun maxInts() {
+        intArrayOf(12, 8, 16)
+                .toFlux()
+                .max()
+                .test()
+                .expectNext(16)
+                .verifyComplete()
+    }
+
+    @Test
+    fun maxLongs() {
+        longArrayOf(12, 8, 16)
+                .toFlux()
+                .max()
+                .test()
+                .expectNext(16)
+                .verifyComplete()
+    }
+
+    @Test
+    fun maxFloats() {
+        floatArrayOf(12f, 8.1f, 16f, 8.2f)
+                .toFlux()
+                .max()
+                .test()
+                .expectNext(16f)
+                .verifyComplete()
+    }
+
+    @Test
+    fun maxDoubles() {
+        doubleArrayOf(12.0, 8.1, 16.0, 8.2)
+                .toFlux()
+                .max()
+                .test()
+                .expectNext(16.0)
+                .verifyComplete()
+    }
+
+    @Test
+    fun maxComparables() {
+        comparableList.toFlux()
+                .max()
+                .test()
+                .expectNext("BB")
+                .verifyComplete()
+    }
+
+    @Test
+    fun maxComparator() {
+        userList.toFlux()
+                .max(comparator)
+                .map { it.name }
+                .test()
+                .expectNext("grandpa")
+                .verifyComplete()
+    }
+
+    @Test
+    fun maxComparatorLambdaInverted() {
+        userList.toFlux()
+                .max { a, b -> b.age - a.age }
+                .map { it.name }
+                .test()
+                .expectNext("baby")
+                .verifyComplete()
+    }
+
+//// == collection of numbers ==
+
+    @Test
+    fun numberCollectionSum() {
+        val longs: List<Long> = listOf(1L, 2L, 3L)
+        val floats: List<Float> = listOf(1.5f, 2.5f)
+        val doubles: List<Double> = listOf(1.6, 2.6)
+
+        Flux.concat(
+                longs.toFlux().sum(),
+                floats.toFlux().sum(),
+                doubles.toFlux().sum())
+                .test()
+                .expectNext(6L)
+                .expectNext(3L).`as`("floats rounded down")
+                .expectNext(3L).`as`("doubles rounded down")
+                .verifyComplete()
+    }
+
+    @Test
+    fun numberCollectionDoubleSum() {
+        val longs: List<Long> = listOf(1L, 2L, 3L)
+        //avoid weird 1.6f == 1.600000023841858 precision artifacts
+        val floats: List<Float> = listOf(1.5f, 2.5f)
+        val doubles: List<Double> = listOf(1.6, 2.6)
+
+        Flux.concat(
+                longs.toFlux().sumDouble(),
+                floats.toFlux().sumDouble(),
+                doubles.toFlux().sumDouble())
+                .test()
+                .expectNext(6.0)
+                .expectNext(4.0).`as`("floats")
+                .expectNext(4.2).`as`("doubles")
+                .verifyComplete()
+    }
+
+}

--- a/reactor-extra/src/test/kotlin/reactor/retry/RepeatExtensionsTests.kt
+++ b/reactor-extra/src/test/kotlin/reactor/retry/RepeatExtensionsTests.kt
@@ -1,0 +1,153 @@
+package reactor.retry
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+import java.time.Duration
+
+class RepeatExtensionsTests {
+
+    @Test
+    fun fluxRepeatExponentialBackoff() {
+        val repeats = mutableListOf<Long>()
+
+        val flux = Flux.range(0, 2)
+                .repeatExponentialBackoff(4, Duration.ofMillis(100),
+                        Duration.ofMillis(500)) { repeats.add(it.backoff().toMillis()) }
+
+        StepVerifier.withVirtualTime { flux }
+                .expectNext(0, 1)
+                .expectNoEvent(Duration.ofMillis(50))  // delay=100
+                .thenAwait(Duration.ofMillis(100))
+                .expectNext(0, 1)
+                .expectNoEvent(Duration.ofMillis(150)) // delay=200
+                .thenAwait(Duration.ofMillis(100))
+                .expectNext(0, 1)
+                .expectNoEvent(Duration.ofMillis(250)) // delay=400
+                .thenAwait(Duration.ofMillis(100))
+                .expectNext(0, 1)
+                .expectNoEvent(Duration.ofMillis(450)) // delay=500
+                .thenAwait(Duration.ofMillis(100))
+                .expectNext(0, 1)
+                .verifyComplete()
+
+        assertThat(repeats).containsExactly(100L, 200L, 400L, 500L)
+    }
+
+    @Test
+    fun monoRepeatExponentialBackoff() {
+        val repeats = mutableListOf<Long>()
+
+        val flux = Mono.just(0)
+                .repeatExponentialBackoff(4, Duration.ofMillis(100),
+                        Duration.ofMillis(500)) { repeats.add(it.backoff().toMillis()) }
+
+        StepVerifier.withVirtualTime { flux }
+                .expectNext(0)
+                .thenAwait(Duration.ofMillis(100))
+                .expectNext(0)
+                .thenAwait(Duration.ofMillis(200))
+                .expectNext(0)
+                .thenAwait(Duration.ofMillis(400))
+                .expectNext(0)
+                .thenAwait(Duration.ofMillis(500))
+                .expectNext(0)
+                .verifyComplete()
+
+        assertThat(repeats).containsExactly(100L, 200L, 400L, 500L)
+    }
+
+    @Test
+    fun fluxRepeatRandomBackoff() {
+        val repeats = mutableListOf<Long>()
+
+        val flux = Flux.range(0, 2)
+                .repeatRandomBackoff(4, Duration.ofMillis(100),
+                        Duration.ofMillis(500)) { repeats.add(it.backoff().toMillis())}
+
+        StepVerifier.withVirtualTime { flux }
+                .expectNext(0, 1)
+                .expectNoEvent(Duration.ofMillis(100))
+                .thenAwait(Duration.ofHours(1))
+                .expectNext(0, 1, 0, 1, 0, 1, 0, 1)
+                .verifyComplete()
+
+        val repeatFirstPass = repeats.toList()
+        repeats.clear()
+        StepVerifier.withVirtualTime { flux }
+                .thenAwait(Duration.ofHours(1))
+                .expectNext(0, 1, 0, 1, 0, 1, 0, 1, 0, 1)
+                .verifyComplete()
+
+        assertThat(repeatFirstPass)
+                .describedAs("first pass")
+                .hasSize(4)
+        
+        assertThat(repeatFirstPass[0])
+                .describedAs("first pass first element")
+                .isBetween(100, 150)
+
+        assertThat(repeats)
+                .describedAs("second pass")
+                .hasSize(4)
+        
+        assertThat(repeats[0])
+                .describedAs("second pass first element")
+                .isBetween(100, 150)
+
+        assertThat(repeats.minus(repeatFirstPass))
+                .describedAs("second pass has at least one different random delay")
+                .isNotEmpty
+    }
+
+
+    @Test
+    fun monoRepeatRandomBackoff() {
+        val repeats = mutableListOf<Long>()
+
+        StepVerifier.withVirtualTime { Mono.just(0)
+                .repeatRandomBackoff(4, Duration.ofMillis(100), Duration.ofMillis(2000)) { repeats.add(it.backoff().toMillis()) }
+                .elapsed()
+                .map { it.t2 }
+        }
+                .expectNext(0)
+                .expectNoEvent(Duration.ofMillis(100))
+                .thenAwait(Duration.ofHours(1))
+                .expectNextCount(4)
+                .verifyComplete()
+
+        val repeatFirstPass = repeats.toList()
+        repeats.clear()
+        StepVerifier.withVirtualTime { Mono.just(0)
+                .repeatRandomBackoff(4, Duration.ofMillis(100), Duration.ofMillis(2000)) { repeats.add(it.backoff().toMillis()) }
+                .elapsed()
+                .map { it.t2 }
+        }
+                .thenAwait(Duration.ofHours(1))
+                .expectNext(0,0,0,0,0)
+                .verifyComplete()
+
+
+        assertThat(repeatFirstPass)
+                .describedAs("first pass")
+                .hasSize(4)
+
+        assertThat(repeatFirstPass[0])
+                .describedAs("first pass first element")
+                .isBetween(100, 150)
+
+        assertThat(repeats)
+                .describedAs("second pass")
+                .hasSize(4)
+
+        assertThat(repeats[0])
+                .describedAs("second pass first element")
+                .isBetween(100, 150)
+
+        assertThat(repeats.minus(repeatFirstPass))
+                .describedAs("second pass has at least one different random delay")
+                .isNotEmpty
+    }
+}

--- a/reactor-extra/src/test/kotlin/reactor/retry/RetryExtensionsTests.kt
+++ b/reactor-extra/src/test/kotlin/reactor/retry/RetryExtensionsTests.kt
@@ -1,0 +1,89 @@
+package reactor.retry
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+import reactor.test.test
+import java.io.IOException
+import java.time.Duration
+
+class RetryExtensionsTests {
+
+    @Test
+    fun fluxRetryExponentialBackoff() {
+        val retries = mutableListOf<Long>()
+
+        Flux.concat(Flux.range(0, 2), Flux.error(IOException()))
+                .retryExponentialBackoff(4, Duration.ofMillis(100),
+                        Duration.ofMillis(500)) { retries.add(it.backoff().toMillis()) }
+                .test()
+                .expectNext(0, 1)
+                .expectNoEvent(Duration.ofMillis(50))  // delay=100
+                .expectNext(0, 1)
+                .expectNoEvent(Duration.ofMillis(150)) // delay=200
+                .expectNext(0, 1)
+                .expectNoEvent(Duration.ofMillis(250)) // delay=400
+                .expectNext(0, 1)
+                .expectNoEvent(Duration.ofMillis(450)) // delay=500
+                .expectNext(0, 1)
+                .verifyError(RetryExhaustedException::class.java)
+
+        assertThat(retries).containsExactly(100, 200, 400, 500)
+    }
+
+    @Test
+    fun monoRetryExponentialBackoff() {
+        val retries = mutableListOf<Long>()
+
+        val mono: Mono<Any> = Mono.error<Any>(IOException())
+                .retryExponentialBackoff(4, Duration.ofMillis(100),
+                        Duration.ofMillis(500)) { retries.add(it.backoff().toMillis()) }
+
+        StepVerifier.withVirtualTime { mono }
+                .expectSubscription()
+                .thenAwait(Duration.ofMillis(100))
+                .thenAwait(Duration.ofMillis(200))
+                .thenAwait(Duration.ofMillis(400))
+                .thenAwait(Duration.ofMillis(500))
+                .verifyError(RetryExhaustedException::class.java)
+
+        assertThat(retries).containsExactly(100L, 200L, 400L, 500L)
+    }
+
+    @Test
+    fun fluxRetryRandomBackoff() {
+        val retries = mutableListOf<Long>()
+
+        Flux.concat(Flux.range(0, 2), Flux.error(IOException()))
+                .retryRandomBackoff(4, Duration.ofMillis(100),
+                        Duration.ofMillis(2000)) { retries.add(it.backoff().toMillis()) }
+                .test()
+                .expectNext(0, 1, 0, 1, 0, 1, 0, 1, 0, 1)
+                .verifyError(RetryExhaustedException::class.java)
+
+        //we'll leave it to java tests to test the retry backoff behavior
+        assertThat(retries).hasSize(4)
+    }
+
+    @Test
+    fun monoRetryRandomBackoff() {
+        val retries = mutableListOf<Long>()
+
+        val mono: Mono<Any> = Mono.error<Any>(IOException())
+                .retryRandomBackoff(4, Duration.ofMillis(100),
+                        Duration.ofMillis(2000)) { retries.add(it.backoff().toMillis()) }
+
+        StepVerifier.withVirtualTime { mono }
+                .expectSubscription()
+                .thenAwait(Duration.ofMillis(100))
+                .thenAwait(Duration.ofMillis(2000))
+                .thenAwait(Duration.ofMillis(2000))
+                .thenAwait(Duration.ofMillis(2000))
+                .verifyError(RetryExhaustedException::class.java)
+
+        //we'll leave it to java tests to test the retry backoff behavior
+        assertThat(retries).hasSize(4)
+    }
+}

--- a/reactor-extra/src/test/kotlin/reactor/retry/RetryExtensionsTests.kt
+++ b/reactor-extra/src/test/kotlin/reactor/retry/RetryExtensionsTests.kt
@@ -5,7 +5,7 @@ import org.junit.Test
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.test.StepVerifier
-import reactor.test.test
+import reactor.kotlin.test.test
 import java.io.IOException
 import java.time.Duration
 


### PR DESCRIPTION
This includes pointers to `reactor-kotlin-extensions`, and otherwise
reverts "Move kotlin extensions to reactor-kotlin-extensions" commit
( ca0c90c3cf73e632637b1c6f8dbda5ca8592b067 ).