### PR TITLE
Remove RxJava 1 phrase in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 # reactor-adapter
 
-Bridge to RxJava 1 or 2 Observable, Completable, Flowable, Single, Maybe, Scheduler, and also SWT Scheduler, Akka Scheduler ...
+Bridge to RxJava 2 Observable, Completable, Flowable, Single, Maybe, Scheduler, and also SWT Scheduler, Akka Scheduler ...
 
 # reactor-extra
 


### PR DESCRIPTION
Project ships nothing related to RxJava 1 anymore. `README` is not consistent with this fact.