### PR TITLE
fix #211 Add math support for BigInteger and BigDecimal

### DIFF
--- a/reactor-extra/src/main/java/reactor/math/MathFlux.java
+++ b/reactor-extra/src/main/java/reactor/math/MathFlux.java
@@ -16,6 +16,7 @@
 
 package reactor.math;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Comparator;
 import java.util.function.Function;
@@ -158,6 +159,29 @@ public final class MathFlux {
 	public static final <T> Mono<BigInteger> sumBigInteger(Publisher<T> source,
 			Function<? super T, ? extends Number> mapping) {
 		return MathMono.onAssembly(new MonoSumBigInteger<T>(source, mapping));
+	}
+
+	/**
+	 * Computes the {@link BigDecimal} sum of items in the source.
+	 *
+	 * @param source the numerical source
+	 * @return {@link Mono} of the sum of items in source
+	 */
+	public static Mono<BigDecimal> sumBigDecimal(Publisher<? extends Number> source) {
+		return sumBigDecimal(source, i -> i);
+	}
+
+	/**
+	 * Computes the {@link BigDecimal} sum of items in the source, which are
+	 * mapped to numerical values using provided mapping.
+	 *
+	 * @param source  the source items
+	 * @param mapping a function to map source items to numerical values
+	 * @return {@link Mono} of sum of items in source
+	 */
+	public static final <T> Mono<BigDecimal> sumBigDecimal(Publisher<T> source,
+			Function<? super T, ? extends Number> mapping) {
+		return MathMono.onAssembly(new MonoSumBigDecimal<T>(source, mapping));
 	}
 
 	/**

--- a/reactor-extra/src/main/java/reactor/math/MathFlux.java
+++ b/reactor-extra/src/main/java/reactor/math/MathFlux.java
@@ -16,6 +16,7 @@
 
 package reactor.math;
 
+import java.math.BigInteger;
 import java.util.Comparator;
 import java.util.function.Function;
 
@@ -134,6 +135,29 @@ public final class MathFlux {
 	 */
 	public static final <T> Mono<Double> sumDouble(Publisher<T> source, Function<? super T, ? extends Number> mapping) {
 		return MathMono.onAssembly(new MonoSumDouble<T>(source, mapping));
+	}
+
+	/**
+	 * Computes the {@link BigInteger} sum of items in the source.
+	 *
+	 * @param source the numerical source
+	 * @return {@link Mono} of the sum of items in source
+	 */
+	public static Mono<BigInteger> sumBigInteger(Publisher<? extends Number> source) {
+		return sumBigInteger(source, i -> i);
+	}
+
+	/**
+	 * Computes the {@link BigInteger} sum of items in the source, which are mapped to
+	 * numerical values using provided mapping.
+	 *
+	 * @param source  the source items
+	 * @param mapping a function to map source items to numerical values
+	 * @return {@link Mono} of sum of items in source
+	 */
+	public static final <T> Mono<BigInteger> sumBigInteger(Publisher<T> source,
+			Function<? super T, ? extends Number> mapping) {
+		return MathMono.onAssembly(new MonoSumBigInteger<T>(source, mapping));
 	}
 
 	/**

--- a/reactor-extra/src/main/java/reactor/math/MathFlux.java
+++ b/reactor-extra/src/main/java/reactor/math/MathFlux.java
@@ -233,6 +233,53 @@ public final class MathFlux {
 	}
 
 	/**
+	 * Computes the {@link BigInteger} average of items in the source.
+	 *
+	 * @param source the numerical source
+	 * @return {@link Mono} of the average of items in source
+	 */
+	public static Mono<BigInteger> averageBigInteger(Publisher<? extends Number> source) {
+		return averageBigInteger(source, i -> i);
+	}
+
+	/**
+	 * Computes the {@link BigInteger} average of items in the source, which are mapped to
+	 * numerical values using the provided mapping.
+	 *
+	 * @param source  the source items
+	 * @param mapping a function to map source items to numerical values
+	 * @return {@link Mono} of the average of items in source
+	 */
+	public static final <T> Mono<BigInteger> averageBigInteger(Publisher<T> source,
+			Function<? super T, ? extends Number> mapping) {
+		return MathMono.onAssembly(new MonoAverageBigInteger<T>(source, mapping));
+	}
+
+
+	/**
+	 * Computes the {@link BigDecimal} average of items in the source.
+	 *
+	 * @param source the numerical source
+	 * @return {@link Mono} of the average of items in source
+	 */
+	public static Mono<BigDecimal> averageBigDecimal(Publisher<? extends Number> source) {
+		return averageBigDecimal(source, i -> i);
+	}
+
+	/**
+	 * Computes the {@link BigDecimal} average of items in the source, which are mapped to
+	 * numerical values using the provided mapping.
+	 *
+	 * @param source  the source items
+	 * @param mapping a function to map source items to numerical values
+	 * @return {@link Mono} of the average of items in source
+	 */
+	public static final <T> Mono<BigDecimal> averageBigDecimal(Publisher<T> source,
+			Function<? super T, ? extends Number> mapping) {
+		return MathMono.onAssembly(new MonoAverageBigDecimal<T>(source, mapping));
+	}
+
+	/**
 	 * Computes the maximum value of items in the source.
 	 *
 	 * @param source the source containing comparable items

--- a/reactor-extra/src/main/java/reactor/math/MonoAverageBigDecimal.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoAverageBigDecimal.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2011-2019 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.math;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.function.Function;
+
+import org.reactivestreams.Publisher;
+import reactor.core.CoreSubscriber;
+import reactor.core.Fuseable;
+import reactor.core.publisher.Flux;
+
+/**
+ * Computes the average of source numbers and returns the result as a {@link BigDecimal}.
+ *
+ * @param <T> the input value type
+ */
+public class MonoAverageBigDecimal<T> extends MonoFromFluxOperator<T, BigDecimal>
+		implements Fuseable {
+
+	private final Function<? super T, ? extends Number> mapping;
+
+	MonoAverageBigDecimal(Publisher<T> source,
+			Function<? super T, ? extends Number> mapping) {
+		super(Flux.from(source));
+		this.mapping = mapping;
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super BigDecimal> actual) {
+		source.subscribe(new AverageBigDecimalSubscriber<T>(actual, mapping));
+	}
+
+	private static final class AverageBigDecimalSubscriber<T>
+			extends MathSubscriber<T, BigDecimal> {
+
+		private final Function<? super T, ? extends Number> mapping;
+
+		private int count;
+
+		private BigDecimal sum = BigDecimal.ZERO;
+
+		AverageBigDecimalSubscriber(CoreSubscriber<? super BigDecimal> actual,
+				Function<? super T, ? extends Number> mapping) {
+			super(actual);
+			this.mapping = mapping;
+		}
+
+		@Override
+		protected void reset() {
+			count = 0;
+			sum = BigDecimal.ZERO;
+		}
+
+		@Override
+		protected BigDecimal result() {
+			return (count == 0 ? null : sum.divide(BigDecimal.valueOf(count)));
+		}
+
+		@Override
+		protected void updateResult(T newValue) {
+			Number number = mapping.apply(newValue);
+			BigDecimal bigDecimalValue = BigDecimal.valueOf(number.doubleValue());
+			sum = sum.add(bigDecimalValue);
+			count++;
+		}
+	}
+}

--- a/reactor-extra/src/main/java/reactor/math/MonoAverageBigInteger.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoAverageBigInteger.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2011-2019 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.math;
+
+import java.math.BigInteger;
+import java.util.function.Function;
+
+import org.reactivestreams.Publisher;
+import reactor.core.CoreSubscriber;
+import reactor.core.Fuseable;
+import reactor.core.publisher.Flux;
+
+/**
+ * Computes the average of source numbers and returns the result as a {@link BigInteger}.
+ *
+ * @param <T> the input value type
+ */
+public class MonoAverageBigInteger<T> extends MonoFromFluxOperator<T, BigInteger>
+		implements Fuseable {
+
+	private final Function<? super T, ? extends Number> mapping;
+
+	MonoAverageBigInteger(Publisher<T> source,
+			Function<? super T, ? extends Number> mapping) {
+		super(Flux.from(source));
+		this.mapping = mapping;
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super BigInteger> actual) {
+		source.subscribe(new AverageBigIntegerSubscriber<T>(actual, mapping));
+	}
+
+	private static final class AverageBigIntegerSubscriber<T>
+			extends MathSubscriber<T, BigInteger> {
+
+		private final Function<? super T, ? extends Number> mapping;
+
+		private int count;
+
+		private BigInteger sum = BigInteger.ZERO;
+
+		AverageBigIntegerSubscriber(CoreSubscriber<? super BigInteger> actual,
+				Function<? super T, ? extends Number> mapping) {
+			super(actual);
+			this.mapping = mapping;
+		}
+
+		@Override
+		protected void reset() {
+			count = 0;
+			sum = BigInteger.ZERO;
+		}
+
+		@Override
+		protected BigInteger result() {
+			return (count == 0 ? null : sum.divide(BigInteger.valueOf(count)));
+		}
+
+		@Override
+		protected void updateResult(T newValue) {
+			Number number = mapping.apply(newValue);
+			BigInteger bigIntegerValue = BigInteger.valueOf(number.longValue());
+			sum = sum.add(bigIntegerValue);
+			count++;
+		}
+	}
+}

--- a/reactor-extra/src/main/java/reactor/math/MonoSumBigDecimal.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoSumBigDecimal.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2011-2019 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.math;
+
+import java.math.BigDecimal;
+import java.util.function.Function;
+
+import org.reactivestreams.Publisher;
+import reactor.core.CoreSubscriber;
+import reactor.core.Fuseable;
+import reactor.core.publisher.Flux;
+
+/**
+ * Computes the sun of source numbers and returns the result as {@link BigDecimal}
+ *
+ * @param <T> the input value type
+ */
+public class MonoSumBigDecimal<T> extends MonoFromFluxOperator<T, BigDecimal>
+		implements Fuseable {
+
+	private final Function<? super T, ? extends Number> mapping;
+
+	MonoSumBigDecimal(Publisher<T> source,
+			Function<? super T, ? extends Number> mapping) {
+		super(Flux.from(source));
+		this.mapping = mapping;
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super BigDecimal> actual) {
+		source.subscribe(new SumBigDecimalSubscriber<T>(actual, mapping));
+	}
+
+	static final private class SumBigDecimalSubscriber<T>
+			extends MathSubscriber<T, BigDecimal> {
+
+		private final Function<? super T, ? extends Number> mapping;
+
+		BigDecimal sum;
+
+		boolean hasValue;
+
+		SumBigDecimalSubscriber(CoreSubscriber<? super BigDecimal> actual,
+				Function<? super T, ? extends Number> mapping) {
+			super(actual);
+			this.mapping = mapping;
+		}
+
+		@Override
+		protected void reset() {
+			sum = BigDecimal.ZERO;
+			hasValue = false;
+		}
+
+		@Override
+		protected BigDecimal result() {
+			return (hasValue ? sum : null);
+		}
+
+		@Override
+		protected void updateResult(T newValue) {
+			Number number = mapping.apply(newValue);
+			BigDecimal bigDecimalValue = BigDecimal.valueOf(number.doubleValue());
+			sum = hasValue ? sum.add(bigDecimalValue) : bigDecimalValue;
+			hasValue = true;
+		}
+	}
+}

--- a/reactor-extra/src/main/java/reactor/math/MonoSumBigInteger.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoSumBigInteger.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2011-2019 Pivotal Software Inc, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.math;
+
+import java.math.BigInteger;
+import java.util.function.Function;
+
+import org.reactivestreams.Publisher;
+import reactor.core.CoreSubscriber;
+import reactor.core.Fuseable;
+import reactor.core.publisher.Flux;
+
+/**
+ * Computes the sun of source numbers and returns the result as {@link BigInteger}
+ *
+ * @param <T> the input value type
+ */
+final class MonoSumBigInteger<T> extends MonoFromFluxOperator<T, BigInteger>
+		implements Fuseable {
+
+	private final Function<? super T, ? extends Number> mapping;
+
+	MonoSumBigInteger(Publisher<? extends T> source,
+			Function<? super T, ? extends Number> mapping) {
+		super(Flux.from(source));
+		this.mapping = mapping;
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super BigInteger> actual) {
+		source.subscribe(new SumBigIntegerSubscriber<T>(actual, mapping));
+	}
+
+	static final private class SumBigIntegerSubscriber<T>
+			extends MathSubscriber<T, BigInteger> {
+
+		private final Function<? super T, ? extends Number> mapping;
+
+		BigInteger sum;
+
+		boolean hasValue;
+
+		SumBigIntegerSubscriber(CoreSubscriber<? super BigInteger> actual,
+				Function<? super T, ? extends Number> mapping) {
+			super(actual);
+			this.mapping = mapping;
+		}
+
+		@Override
+		protected void reset() {
+			sum = BigInteger.ZERO;
+			hasValue = false;
+		}
+
+		@Override
+		protected BigInteger result() {
+			return (hasValue ? sum : null);
+		}
+
+		@Override
+		protected void updateResult(T newValue) {
+			Number number = mapping.apply(newValue);
+			BigInteger bigIntegerValue = BigInteger.valueOf(number.longValue());
+			sum = hasValue ? sum.add(bigIntegerValue) : bigIntegerValue;
+			hasValue = true;
+		}
+	}
+}

--- a/reactor-extra/src/test/java/reactor/math/ReactorMathTests.java
+++ b/reactor-extra/src/test/java/reactor/math/ReactorMathTests.java
@@ -16,6 +16,7 @@
 
 package reactor.math;
 
+import java.math.BigInteger;
 import java.util.Comparator;
 
 import org.junit.Test;
@@ -137,6 +138,42 @@ public class ReactorMathTests {
 	@Test
 	public void emptySumDouble() {
 		verifyEmptyResult(MathFlux.sumDouble(Mono.empty()));
+	}
+
+	@Test
+	public void fluxSumBigInteger() {
+		int count = 10;
+		BigInteger sum = BigInteger.valueOf(sum(count));
+		verifyResult(MathFlux.sumBigInteger(bigIntegerFlux(count)), sum);
+		verifyResult(MathFlux.sumBigInteger(Flux.just(BigInteger.valueOf(Long.MAX_VALUE),
+				BigInteger.valueOf(Long.MAX_VALUE))),
+				BigInteger.valueOf(Long.MAX_VALUE)
+				          .multiply(BigInteger.valueOf(2)));
+		verifyResult(MathFlux.sumBigInteger(intFlux(count),
+				i -> i), sum);
+		verifyResult(MathFlux.sumBigInteger(doubleFlux(count),
+				i -> i), sum);
+		verifyResult(MathFlux.sumBigInteger(stringFlux(count), BigInteger::new), sum);
+
+		verifyResult(bigIntegerFlux(count).as(MathFlux::sumBigInteger), sum);
+		verifyResult(bigIntegerFlux(count).transform(MathFlux::sumBigInteger), sum);
+		verifyResult(doubleFlux(count).as(MathFlux::sumBigInteger), sum);
+		verifyResult(doubleFlux(count).transform(MathFlux::sumBigInteger), sum);
+		verifyResult(intFlux(count).as(MathFlux::sumBigInteger), sum);
+		verifyResult(intFlux(count).transform(MathFlux::sumBigInteger), sum);
+	}
+
+	@Test
+	public void monoSumBigInteger() {
+		verifyResult(MathFlux.sumBigInteger(Mono.just(BigInteger.ONE)), BigInteger.ONE);
+		verifyResult(MathFlux.sumBigInteger(Mono.just("10"), BigInteger::new),
+				BigInteger.TEN);
+		verifyResult(MathFlux.sumBigInteger(Mono.just(1.5)), BigInteger.ONE);
+	}
+
+	@Test
+	public void emptySumBigInteger() {
+		verifyEmptyResult(MathFlux.sumBigInteger(Mono.empty()));
 	}
 
 	@Test
@@ -295,6 +332,10 @@ public class ReactorMathTests {
 
 	Flux<Double> doubleFlux(int count) {
 		return Flux.range(1, count).map(i -> (double) i.intValue());
+	}
+
+	Flux<BigInteger> bigIntegerFlux(int count) {
+		return Flux.range(1, count).map(BigInteger::valueOf);
 	}
 
 	Flux<String> stringFlux(int count) {

--- a/reactor-extra/src/test/java/reactor/math/ReactorMathTests.java
+++ b/reactor-extra/src/test/java/reactor/math/ReactorMathTests.java
@@ -16,6 +16,7 @@
 
 package reactor.math;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Comparator;
 
@@ -174,6 +175,44 @@ public class ReactorMathTests {
 	@Test
 	public void emptySumBigInteger() {
 		verifyEmptyResult(MathFlux.sumBigInteger(Mono.empty()));
+	}
+
+	@Test
+	public void fluxSumBigDecimal() {
+		int count = 10;
+		BigDecimal sum = BigDecimal.valueOf(sum(count));
+		verifyBigDecimalResult(MathFlux.sumBigDecimal(bigDecimalFlux(count)), sum);
+		verifyBigDecimalResult(MathFlux.sumBigDecimal(Flux.just(BigDecimal.valueOf(Double.MAX_VALUE),
+				BigDecimal.valueOf(Double.MAX_VALUE))),
+				BigDecimal.valueOf(Double.MAX_VALUE)
+				          .multiply(BigDecimal.valueOf(2)));
+		verifyBigDecimalResult(MathFlux.sumBigDecimal(intFlux(count), i -> i), sum);
+		verifyBigDecimalResult(MathFlux.sumBigDecimal(doubleFlux(count), i -> i), sum);
+		verifyBigDecimalResult(MathFlux.sumBigDecimal(stringFlux(count), BigDecimal::new),
+				sum);
+
+		verifyBigDecimalResult(bigDecimalFlux(count).as(MathFlux::sumBigDecimal), sum);
+		verifyBigDecimalResult(bigDecimalFlux(count).transform(MathFlux::sumBigDecimal),
+				sum);
+		verifyBigDecimalResult(doubleFlux(count).as(MathFlux::sumBigDecimal), sum);
+		verifyBigDecimalResult(doubleFlux(count).transform(MathFlux::sumBigDecimal), sum);
+		verifyBigDecimalResult(intFlux(count).as(MathFlux::sumBigDecimal), sum);
+		verifyBigDecimalResult(intFlux(count).transform(MathFlux::sumBigDecimal), sum);
+	}
+
+	@Test
+	public void monoSumBigDecimal() {
+		verifyBigDecimalResult(MathFlux.sumBigDecimal(Mono.just(BigDecimal.ONE)),
+				BigDecimal.ONE);
+		verifyBigDecimalResult(MathFlux.sumBigDecimal(Mono.just("10"), BigDecimal::new),
+				BigDecimal.TEN);
+		verifyBigDecimalResult(MathFlux.sumBigDecimal(Mono.just(1.5)),
+				BigDecimal.valueOf(1.5D));
+	}
+
+	@Test
+	public void emptySumBigDecimal() {
+		verifyEmptyResult(MathFlux.sumBigDecimal(Mono.empty()));
 	}
 
 	@Test
@@ -338,6 +377,10 @@ public class ReactorMathTests {
 		return Flux.range(1, count).map(BigInteger::valueOf);
 	}
 
+	Flux<BigDecimal> bigDecimalFlux(int count) {
+		return Flux.range(1, count).map(BigDecimal::valueOf);
+	}
+
 	Flux<String> stringFlux(int count) {
 		return Flux.range(1, count).map(i -> i.toString());
 	}
@@ -362,6 +405,15 @@ public class ReactorMathTests {
 		StepVerifier.create(resultMono)
 					.expectComplete()
 					.verify();
+	}
+
+	void verifyBigDecimalResult(Publisher<BigDecimal> resultMono,
+			BigDecimal expectedResult) {
+		StepVerifier.create(resultMono)
+		            .expectNextMatches(t -> expectedResult.compareTo(t) == 0)
+		            .expectNext()
+		            .expectComplete()
+		            .verify();
 	}
 
 	static class StringLengthComparator implements Comparator<String> {

--- a/reactor-extra/src/test/java/reactor/math/ReactorMathTests.java
+++ b/reactor-extra/src/test/java/reactor/math/ReactorMathTests.java
@@ -270,6 +270,81 @@ public class ReactorMathTests {
 	}
 
 	@Test
+	public void fluxAverageBigInteger() {
+		int count = 10;
+		BigInteger average = BigInteger.valueOf(Double.valueOf(average(count))
+		                                              .longValue());
+		verifyResult(MathFlux.averageBigInteger(bigIntegerFlux(count)), average);
+		verifyResult(MathFlux.averageBigInteger(Flux.just(Long.MAX_VALUE,
+				Long.MAX_VALUE)),
+				BigInteger.valueOf(Long.MAX_VALUE)
+				          .multiply(BigInteger.valueOf(2))
+				          .divide(BigInteger.valueOf(2)));
+		verifyResult(MathFlux.averageBigInteger(intFlux(count), i -> i), average);
+		verifyResult(MathFlux.averageBigInteger(stringFlux(count), Long::parseLong),
+				average);
+
+		verifyResult(doubleFlux(count).as(MathFlux::averageBigInteger), average);
+		verifyResult(doubleFlux(count).transform(MathFlux::averageBigInteger), average);
+		verifyResult(intFlux(count).as(MathFlux::averageBigInteger), average);
+		verifyResult(intFlux(count).transform(MathFlux::averageBigInteger), average);
+	}
+
+	@Test
+	public void monoAverageBigInteger() {
+		verifyResult(MathFlux.averageBigInteger(Mono.just(2.5)), BigInteger.valueOf(2));
+		verifyResult(MathFlux.averageBigInteger(Mono.just(2), i -> i),
+				BigInteger.valueOf(2));
+		verifyResult(MathFlux.averageBigInteger(Mono.just("1"), Long::parseLong),
+				BigInteger.ONE);
+	}
+
+	@Test
+	public void emptyAverageBigInteger() {
+		verifyEmptyResult(MathFlux.averageBigInteger(Mono.empty()));
+	}
+
+	@Test
+	public void fluxAverageBigDecimal() {
+		int count = 10;
+		BigDecimal average = BigDecimal.valueOf(average(count));
+		verifyBigDecimalResult(MathFlux.averageBigDecimal(bigDecimalFlux(count)),
+				average);
+		verifyBigDecimalResult(MathFlux.averageBigDecimal(Flux.just(Double.MAX_VALUE,
+				Double.MAX_VALUE)),
+				BigDecimal.valueOf(Double.MAX_VALUE)
+				          .multiply(BigDecimal.valueOf(2))
+				          .divide(BigDecimal.valueOf(2)));
+		verifyBigDecimalResult(MathFlux.averageBigDecimal(intFlux(count), i -> i),
+				average);
+		verifyBigDecimalResult(MathFlux.averageBigDecimal(stringFlux(count),
+				Double::parseDouble), average);
+
+		verifyBigDecimalResult(doubleFlux(count).as(MathFlux::averageBigDecimal),
+				average);
+		verifyBigDecimalResult(doubleFlux(count).transform(MathFlux::averageBigDecimal),
+				average);
+		verifyBigDecimalResult(intFlux(count).as(MathFlux::averageBigDecimal), average);
+		verifyBigDecimalResult(intFlux(count).transform(MathFlux::averageBigDecimal),
+				average);
+	}
+
+	@Test
+	public void monoAverageBigDecimal() {
+		verifyBigDecimalResult(MathFlux.averageBigDecimal(Mono.just(2.5)),
+				BigDecimal.valueOf(2.5));
+		verifyBigDecimalResult(MathFlux.averageBigDecimal(Mono.just(2), i -> i),
+				BigDecimal.valueOf(2));
+		verifyBigDecimalResult(MathFlux.averageBigDecimal(Mono.just("1.5"),
+				Double::parseDouble), BigDecimal.valueOf(1.5));
+	}
+
+	@Test
+	public void emptyAverageBigDecimal() {
+		verifyEmptyResult(MathFlux.averageBigDecimal(Mono.empty()));
+	}
+
+	@Test
 	public void fluxMax() {
 		verifyResult(MathFlux.max(Flux.just(5, 1, 2, 6, 3)), 6);
 		verifyResult(MathFlux.max(Flux.range(1, 10)), 10);


### PR DESCRIPTION
Hi, this PR add follow features to MathFlux:

- sumBigInteger; 
- averageBigInteger; 
- sumBigDecimal; 
- averageDecimal.

Issue requested => #211 
