### PR TITLE
Expose iteration count in RetryExhaustedException

### DIFF
--- a/reactor-extra/src/main/java/reactor/retry/DefaultRetry.java
+++ b/reactor-extra/src/main/java/reactor/retry/DefaultRetry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2020 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -127,7 +127,7 @@ public class DefaultRetry<T> extends AbstractRetry<T, Throwable> implements Retr
 		}
 		else if (nextBackoff == RETRY_EXHAUSTED) {
 			log.debug("Retries exhausted, retry context: {}", retryContext);
-			return Mono.error(new RetryExhaustedException(e));
+			return Mono.error(new RetryExhaustedException(e, iteration));
 		}
 		else {
 			log.debug("Scheduling retry attempt, retry context: {}", retryContext);

--- a/reactor-extra/src/main/java/reactor/retry/RetryExhaustedException.java
+++ b/reactor-extra/src/main/java/reactor/retry/RetryExhaustedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Pivotal Software Inc, All Rights Reserved.
+ * Copyright (c) 2017-2020 Pivotal Software Inc, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,8 @@ public class RetryExhaustedException extends RuntimeException {
 
 	private static final long serialVersionUID = 6961442923363481283L;
 
+	private long iterationCount = -1L;
+
 	public RetryExhaustedException() {
 		super();
 	}
@@ -45,5 +47,19 @@ public class RetryExhaustedException extends RuntimeException {
 
 	public RetryExhaustedException(Throwable cause) {
 		super(cause);
+	}
+
+	public RetryExhaustedException(Throwable cause, long iterationCount) {
+		super(cause);
+		this.iterationCount = iterationCount;
+	}
+
+	/**
+	 * Exposes the total number of iterations (i.e. retries + initial attempt) before retries were exhausted.
+	 *
+	 * @return the iteration count or -1 if unavailable.
+	 */
+	public long getIterationCount() {
+		return iterationCount;
 	}
 }


### PR DESCRIPTION
In order to improve our monitoring, we would like to get hold of the iteration count when a `RetryExhaustedException` is thrown. The number of retries before exhaustion can be variable for example when using timeouts, jitter, etc.

This pull request adds an `iterationCount` field to the `RetryExhaustedException` class, with a getter and a new constructor. All existing constructors were kept as is to avoid breaking integrations that may be creating instances of this exception explicitly.

Thanks in advance for the feedback!