### PR TITLE
[build] master is 3.4 Europium, introduce new versioning scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,19 +36,19 @@ Snapshot and pre-release Maven artifacts are provided in the SpringSource snapsh
 To add this repo to your Gradle build, specify the URL like the following:
 
     ext {
-      reactorAddonsVersion = '3.3.3.RELEASE'
+      reactorAddonsVersion = '3.4.0-SNAPSHOT'
     }
 
     repositories {
       //maven { url 'https://repo.spring.io/release' }
-      maven { url 'https://repo.spring.io/milestone' }
-      //maven { url 'https://repo.spring.io/snapshot' }
+      //maven { url 'https://repo.spring.io/milestone' }
+      maven { url 'https://repo.spring.io/snapshot' }
       mavenCentral()
     }
 
     dependencies {
       // Reactor Adapter (RxJava2, Akka Actors scheduler and more)
-      // compile "io.projectreactor.addons:reactor-adapter:$reactorAddonsVersion"
+      compile "io.projectreactor.addons:reactor-adapter:$reactorAddonsVersion"
     }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -154,7 +154,7 @@ configure(subprojects) { project ->
   }
 
   repositories {
-	if (version.endsWith('BUILD-SNAPSHOT')) {
+	if (version.endsWith('-SNAPSHOT')) {
 	  mavenLocal()
 	  maven { url 'https://repo.spring.io/libs-snapshot' }
 	}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=3.3.4.BUILD-SNAPSHOT
-reactorCoreVersion=3.3.5.BUILD-SNAPSHOT
+version=3.4.0-SNAPSHOT
+reactorCoreVersion=3.4.0-SNAPSHOT

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -60,7 +60,7 @@ task bumpVersionsInReadme(type: Copy, group: "releaser helpers", description: "r
 	def oldVersion = rootProject.findProperty("oldVersion")
 	def currentVersion = rootProject.findProperty("currentVersion")
 	def nextVersion = rootProject.findProperty("nextVersion")
-	def oldSnapshot = currentVersion?.replace("RELEASE", "BUILD-SNAPSHOT")
+	def oldSnapshot = currentVersion + "-SNAPSHOT"
 
 	onlyIf { oldVersion != null && currentVersion != null && nextVersion != null }
 	dependsOn copyReadme

--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -69,11 +69,6 @@ publishing {
 				}
 				developers {
 					developer {
-						id = 'smaldini'
-						name = 'Stephane Maldini'
-						email = 'smaldini@pivotal.io'
-					}
-					developer {
 						id = 'simonbasle'
 						name = 'Simon Baslé'
 						email = 'sbasle@pivotal.io'


### PR DESCRIPTION
This commit switches the effort on master from 3.3 to 3.4.0.
It also introduces a new versioning scheme, using -SNAPSHOT
instead of .BUILD-SNAPSHOT as the qualifier for snapshots.

The whole scheme is detailed in the reference documentation
of core, adaptations are made to the build script to
accommodate it.

See reactor/reactor#683