### PR TITLE
Switch to private constructors in utility classes

### DIFF
--- a/reactor-extra/src/main/java/reactor/cache/CacheFlux.java
+++ b/reactor-extra/src/main/java/reactor/cache/CacheFlux.java
@@ -70,7 +70,9 @@ import reactor.core.publisher.Signal;
  * @author Simon Baslé
  */
 public class CacheFlux {
-
+	
+	private CacheFlux() {
+	}
 
 	/**
 	 * Restore a {@link Flux Flux&lt;VALUE&gt;} from the cache-map given a provided key.

--- a/reactor-extra/src/main/java/reactor/cache/CacheMono.java
+++ b/reactor-extra/src/main/java/reactor/cache/CacheMono.java
@@ -65,6 +65,9 @@ import reactor.core.publisher.Signal;
  * @author Simon Baslé
  */
 public class CacheMono {
+	
+	private CacheMono() {
+	}
 
 	/**
 	 * Restore a {@link Mono Mono&lt;VALUE&gt;} from the cache-map given a provided key. If no value

--- a/reactor-extra/src/main/java/reactor/math/MathFlux.java
+++ b/reactor-extra/src/main/java/reactor/math/MathFlux.java
@@ -29,7 +29,7 @@ import reactor.core.publisher.Mono;
  * Mathematical utilities that compute sum, average, minimum or maximum values
  * from numerical sources or sources that can be mapped to numerical values using
  * custom mappings. Minimum and maximum values can be computed for any source
- * containing {@link Comparable} values or using custom @link {@link Comparator}.
+ * containing {@link Comparable} values or using custom {@link Comparator}.
  *
  */
 public final class MathFlux {

--- a/reactor-extra/src/main/java/reactor/math/MathFlux.java
+++ b/reactor-extra/src/main/java/reactor/math/MathFlux.java
@@ -33,6 +33,9 @@ import reactor.core.publisher.Mono;
  *
  */
 public final class MathFlux {
+	
+	private MathFlux() {
+	}
 
 	/**
 	 * Computes the integer sum of items in the source. Note that in case of an overflow,


### PR DESCRIPTION
`BooleanUtils` has a private constructor preventing instantiation, but other utility classes do not (resulting in a public constructor being available that serves no purpose.)

Added private constructors to other utility classes (trivial change.)