### PR TITLE
fix #243 Publish to Artifactory via a github action ()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         ORG_GRADLE_PROJECT_artifactory_publish_username: ${{secrets.ORG_GRADLE_PROJECT_ARTIFACTORY_PUBLISH_USERNAME}}
         ORG_GRADLE_PROJECT_artifactory_publish_password: ${{secrets.ORG_GRADLE_PROJECT_ARTIFACTORY_PUBLISH_PASSWORD}}
       with:
-        arguments: check javadoc artifactoryPublish -Partifactory_publish_contextUrl=https://repo.spring.io
+        arguments: check assemble artifactoryPublish -Partifactory_publish_contextUrl=https://repo.spring.io
         wrapper-cache-enabled: true
         dependencies-cache-enabled: true
         configuration-cache-enabled: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - "243-artifactory-gha" # TODO remove
 jobs:
   checks:
-    name: checks
+    name: publication
     runs-on: ubuntu-latest
     steps:
     # the skip-duplicate-actions step actually applies to the whole workflow
@@ -21,6 +21,10 @@ jobs:
         java-version: 8
     - uses: eskatos/gradle-command-action@v1
       name: gradle
+      env:
+        ORG_GRADLE_PROJECT_artifactory_publish_contextUrl: ${{secrets.ORG_GRADLE_PROJECT_ARTIFACTORY_PUBLISH_CONTEXTURL}}
+        ORG_GRADLE_PROJECT_artifactory_publish_username: ${{secrets.ORG_GRADLE_PROJECT_ARTIFACTORY_PUBLISH_USERNAME}}
+        ORG_GRADLE_PROJECT_artifactory_publish_password: ${{secrets.ORG_GRADLE_PROJECT_ARTIFACTORY_PUBLISH_PASSWORD}}
       with:
         arguments: check javadoc artifactoryPublish
         wrapper-cache-enabled: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - "[0-9].[0-9]+.x"
+      - "243-artifactory-gha" # TODO remove
 jobs:
   checks:
     name: checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - master
       - "[0-9].[0-9]+.x"
-      - "243-artifactory-gha" # TODO remove
 jobs:
   checks:
     name: publication
@@ -22,11 +21,10 @@ jobs:
     - uses: eskatos/gradle-command-action@v1
       name: gradle
       env:
-        ORG_GRADLE_PROJECT_artifactory_publish_contextUrl: ${{secrets.ORG_GRADLE_PROJECT_ARTIFACTORY_PUBLISH_CONTEXTURL}}
         ORG_GRADLE_PROJECT_artifactory_publish_username: ${{secrets.ORG_GRADLE_PROJECT_ARTIFACTORY_PUBLISH_USERNAME}}
         ORG_GRADLE_PROJECT_artifactory_publish_password: ${{secrets.ORG_GRADLE_PROJECT_ARTIFACTORY_PUBLISH_PASSWORD}}
       with:
-        arguments: check javadoc artifactoryPublish
+        arguments: check javadoc artifactoryPublish -Partifactory_publish_contextUrl=https://repo.spring.io
         wrapper-cache-enabled: true
         dependencies-cache-enabled: true
         configuration-cache-enabled: true

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,9 +1,6 @@
-name: CI
+name: PR Checks
 on:
-  push:
-    branches:
-      - master
-      - "[0-9].[0-9]+.x"
+  pull_request: {}
 jobs:
   checks:
     name: checks
@@ -21,7 +18,7 @@ jobs:
     - uses: eskatos/gradle-command-action@v1
       name: gradle
       with:
-        arguments: check javadoc artifactoryPublish
+        arguments: check javadoc
         wrapper-cache-enabled: true
         dependencies-cache-enabled: true
         configuration-cache-enabled: true

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -107,7 +107,7 @@ if (rootProject.hasProperty("artifactory_publish_password")) {
 			contextUrl = "${artifactory_publish_contextUrl}"
 			publish {
 				repository {
-					repoKey = "${artifactory_publish_repoKey}"
+					repoKey = repoKeyFor(p)
 					username = "${artifactory_publish_username}"
 					password = "${artifactory_publish_password}"
 				}
@@ -117,4 +117,18 @@ if (rootProject.hasProperty("artifactory_publish_password")) {
 			clientConfig.info.setBuildNumber(buildNumber)
 		}
 	}
+}
+
+static def repoKeyFor(p) {
+	def repos = [
+			// New scheme
+			(~/^\d+\.\d+\.\d+$/) : "libs-release-local",
+			(~/^\d+\.\d+\.\d+-SNAPSHOT$/) : "libs-snapshot-local",
+			(~/^\d+\.\d+\.\d+\.M\d+$/) : "libs-milestone-local",
+			// Old scheme
+			(~/^\d+\.\d+\.\d+\.RELEASE$/) : "libs-release-local",
+			(~/^\d+\.\d+\.\d+\.BUILD-SNAPSHOT$/) : "libs-snapshot-local",
+			(~/^\d+\.\d+\.\d+\.M\d+$/) : "libs-milestone-local",
+	]
+	return repos.find {e -> p.version =~ e.key}.value
 }

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -99,18 +99,18 @@ task printBuildNumber() {
 	}
 }
 
-if (rootProject.hasProperty("artifactory_publish_password")) {
+if (rootProject.hasProperty("artifactory_publish_password") || System.getenv("ORG_GRADLE_PROJECT_ARTIFACTORY_PUBLISH_PASSWORD") != null) {
 	configure(rootProject) { p ->
-		println "Hello ${artifactory_publish_contextUrl}"
+		println "Hello ${artifactory_publish_contextUrl} -o- " + System.getenv("ORG_GRADLE_PROJECT_ARTIFACTORY_PUBLISH_CONTEXTURL")
 		apply plugin: "com.jfrog.artifactory"
 		def buildNumber = getOrGenerateBuildNumber()
 		artifactory {
-			contextUrl = "${artifactory_publish_contextUrl}"
+			contextUrl = System.getenv("ORG_GRADLE_PROJECT_ARTIFACTORY_PUBLISH_CONTEXTURL") ?: "${artifactory_publish_contextUrl}"
 			publish {
 				repository {
 					repoKey = repoKeyFor(p)
-					username = "${artifactory_publish_username}"
-					password = "${artifactory_publish_password}"
+					username = System.getenv("ORG_GRADLE_PROJECT_ARTIFACTORY_PUBLISH_USERNAME") ?: "${artifactory_publish_username}"
+					password = System.getenv("ORG_GRADLE_PROJECT_ARTIFACTORY_PUBLISH_PASSWORD") ?: "${artifactory_publish_password}"
 				}
 			}
 			clientConfig.setIncludeEnvVars(false)

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -113,7 +113,7 @@ if (rootProject.hasProperty("artifactory_publish_password")) {
 				}
 			}
 			clientConfig.setIncludeEnvVars(false)
-			clientConfig.info.setBuildName('Reactor - Releaser - Addons')
+			clientConfig.info.setBuildName('Reactor - GitHub Actions - Addons')
 			clientConfig.info.setBuildNumber(buildNumber)
 			if (System.getenv("GITHUB_ACTIONS") == "true") {
 				clientConfig.info.setBuildUrl(System.getenv("GITHUB_SERVER_URL") + "/" + System.getenv("GITHUB_REPOSITORY") + "/actions/runs/" + System.getenv("GITHUB_RUN_ID"))

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -82,9 +82,9 @@ String getOrGenerateBuildNumber() {
 	if (project.hasProperty("buildNumber")) {
 		return project.findProperty("buildNumber")
 	}
-	def jenkinsNumber = System.getenv("BUILD_NUMBER")
-	if (jenkinsNumber != null) {
-		return jenkinsNumber
+	def ciNumber = System.getenv("GITHUB_RUN_ID")
+	if (ciNumber != null) {
+		return ciNumber
 	}
 	ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC)
 	long secondsInDay = now.toEpochSecond() - ZonedDateTime.now(ZoneOffset.UTC).withSecond(0).withHour(0).withMinute(0).toEpochSecond()
@@ -115,6 +115,11 @@ if (rootProject.hasProperty("artifactory_publish_password")) {
 			clientConfig.setIncludeEnvVars(false)
 			clientConfig.info.setBuildName('Reactor - Releaser - Addons')
 			clientConfig.info.setBuildNumber(buildNumber)
+			if (System.getenv("GITHUB_ACTIONS") == "true") {
+				clientConfig.info.setBuildUrl(System.getenv("GITHUB_SERVER_URL") + "/" + System.getenv("GITHUB_REPOSITORY") + "/actions/runs/" + System.getenv("GITHUB_RUN_ID"))
+				clientConfig.info.setVcsRevision(System.getenv("GITHUB_SHA"))
+				println clientConfig.info
+			}
 		}
 	}
 }

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -99,18 +99,17 @@ task printBuildNumber() {
 	}
 }
 
-if (rootProject.hasProperty("artifactory_publish_password") || System.getenv("ORG_GRADLE_PROJECT_ARTIFACTORY_PUBLISH_PASSWORD") != null) {
+if (rootProject.hasProperty("artifactory_publish_password")) {
 	configure(rootProject) { p ->
-		println "Hello ${artifactory_publish_contextUrl} -o- " + System.getenv("ORG_GRADLE_PROJECT_ARTIFACTORY_PUBLISH_CONTEXTURL")
 		apply plugin: "com.jfrog.artifactory"
 		def buildNumber = getOrGenerateBuildNumber()
 		artifactory {
-			contextUrl = System.getenv("ORG_GRADLE_PROJECT_ARTIFACTORY_PUBLISH_CONTEXTURL") ?: "${artifactory_publish_contextUrl}"
+			contextUrl = "${artifactory_publish_contextUrl}"
 			publish {
 				repository {
 					repoKey = repoKeyFor(p)
-					username = System.getenv("ORG_GRADLE_PROJECT_ARTIFACTORY_PUBLISH_USERNAME") ?: "${artifactory_publish_username}"
-					password = System.getenv("ORG_GRADLE_PROJECT_ARTIFACTORY_PUBLISH_PASSWORD") ?: "${artifactory_publish_password}"
+					username = "${artifactory_publish_username}"
+					password = "${artifactory_publish_password}"
 				}
 			}
 			clientConfig.setIncludeEnvVars(false)
@@ -119,7 +118,6 @@ if (rootProject.hasProperty("artifactory_publish_password") || System.getenv("OR
 			if (System.getenv("GITHUB_ACTIONS") == "true") {
 				clientConfig.info.setBuildUrl(System.getenv("GITHUB_SERVER_URL") + "/" + System.getenv("GITHUB_REPOSITORY") + "/actions/runs/" + System.getenv("GITHUB_RUN_ID"))
 				clientConfig.info.setVcsRevision(System.getenv("GITHUB_SHA"))
-				println clientConfig.info
 			}
 		}
 	}

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -101,6 +101,7 @@ task printBuildNumber() {
 
 if (rootProject.hasProperty("artifactory_publish_password")) {
 	configure(rootProject) { p ->
+		println "Hello ${artifactory_publish_contextUrl}"
 		apply plugin: "com.jfrog.artifactory"
 		def buildNumber = getOrGenerateBuildNumber()
 		artifactory {
@@ -136,6 +137,8 @@ static def repoKeyFor(p) {
 			(~/^\d+\.\d+\.\d+\.BUILD-SNAPSHOT$/) : "libs-snapshot-local",
 			(~/^\d+\.\d+\.\d+\.M\d+$/) : "libs-milestone-local",
 			(~/^\d+\.\d+\.\d+\.RC\d+$/) : "libs-milestone-local",
+			// Test
+			(~/^\d+\.\d+\.\d+-.+-SNAPSHOT$/) : "libs-snapshot-local",
 	]
 	return repos.find {e -> p.version =~ e.key}.value
 }

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -125,10 +125,12 @@ static def repoKeyFor(p) {
 			(~/^\d+\.\d+\.\d+$/) : "libs-release-local",
 			(~/^\d+\.\d+\.\d+-SNAPSHOT$/) : "libs-snapshot-local",
 			(~/^\d+\.\d+\.\d+\.M\d+$/) : "libs-milestone-local",
+			(~/^\d+\.\d+\.\d+\.RC\d+$/) : "libs-milestone-local",
 			// Old scheme
 			(~/^\d+\.\d+\.\d+\.RELEASE$/) : "libs-release-local",
 			(~/^\d+\.\d+\.\d+\.BUILD-SNAPSHOT$/) : "libs-snapshot-local",
 			(~/^\d+\.\d+\.\d+\.M\d+$/) : "libs-milestone-local",
+			(~/^\d+\.\d+\.\d+\.RC\d+$/) : "libs-milestone-local",
 	]
 	return repos.find {e -> p.version =~ e.key}.value
 }

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -124,8 +124,8 @@ static def repoKeyFor(p) {
 			// New scheme
 			(~/^\d+\.\d+\.\d+$/) : "libs-release-local",
 			(~/^\d+\.\d+\.\d+-SNAPSHOT$/) : "libs-snapshot-local",
-			(~/^\d+\.\d+\.\d+\.M\d+$/) : "libs-milestone-local",
-			(~/^\d+\.\d+\.\d+\.RC\d+$/) : "libs-milestone-local",
+			(~/^\d+\.\d+\.\d+-M\d+$/) : "libs-milestone-local",
+			(~/^\d+\.\d+\.\d+-RC\d+$/) : "libs-milestone-local",
 			// Old scheme
 			(~/^\d+\.\d+\.\d+\.RELEASE$/) : "libs-release-local",
 			(~/^\d+\.\d+\.\d+\.BUILD-SNAPSHOT$/) : "libs-snapshot-local",


### PR DESCRIPTION
This uses code that was already present and maybe? leveraged by the bamboo plugin. There seem to be some remains of other CI for computing a build number, maybe we want to do some additional cleaning...

This splits the existing GHA into a dedicated PR check (does not publish) and CI (does publish, for the appropriate branches only).
This should use the following secrets, ideally configured [at the organisation level](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-an-organization).

```
ORG_GRADLE_PROJECT_artifactory_publish_username
ORG_GRADLE_PROJECT_artifactory_publish_password 
ORG_GRADLE_PROJECT_artifactory_publish_contextUrl
```

