### PR TITLE
Draft a tag and release note on non-snapshot publications

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,33 @@ jobs:
     steps:
     # we DON'T want to cancel previous runs, especially in the case of a "back to snapshots" build right after a release push
     - uses: actions/checkout@v2
+    - uses: christian-draeger/read-properties@1.0.1
+      name: read version
+      id: read-version
+      with:
+        path: './gradle.properties'
+        property: 'version'
+    - uses: frabert/replace-string-action@v1.2
+      id: split-qualifier
+      with:
+        string: ${{ steps.read-version.outputs.value }}
+        pattern: '(\d+\.\d+\.\d+)[.-]?([\w-]*)'
+        replace-with: 'VERSION$2'
+    - name: interpret version
+      id: version-type
+      run: |
+          echo "::set-output name=issnapshot::${{ steps.split-qualifier.outputs.replaced == 'VERSIONSNAPSHOT' || steps.split-qualifier.outputs.replaced == 'VERSIONBUILD-SNAPSHOT'  }}"
+          echo "::set-output name=isprerelease::${{ startsWith(steps.split-qualifier.outputs.replaced,'VERSIONRC') || startsWith(steps.split-qualifier.outputs.replaced,'VERSIONM')  }}"
+          echo "::set-output name=isrelease::${{ steps.split-qualifier.outputs.replaced == 'VERSIONRELEASE' || steps.split-qualifier.outputs.replaced == 'VERSION'  }}"
+          echo "::set-output name=isunknown::${{ startsWith(steps.split-qualifier.outputs.replaced,'VERSION') != true  }}"
+    - name: validate version interpretation
+      if: steps.version-type.outputs.isunknown == 'true'
+      run: |
+          echo "Couldn't classify version"
+          echo "${{ steps.read-version.outputs.value }}"
+          echo "${{ toJson(steps.split-qualifier.outputs) }}"
+          echo "${{ toJson(steps.version-type.outputs) }}"
+          return 1
     - uses: actions/setup-java@v1
       with:
         java-version: 8

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,16 +42,16 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 8
-    - uses: eskatos/gradle-command-action@v1
-      name: gradle
-      env:
-        ORG_GRADLE_PROJECT_artifactory_publish_username: ${{secrets.ORG_GRADLE_PROJECT_ARTIFACTORY_PUBLISH_USERNAME}}
-        ORG_GRADLE_PROJECT_artifactory_publish_password: ${{secrets.ORG_GRADLE_PROJECT_ARTIFACTORY_PUBLISH_PASSWORD}}
-      with:
-        arguments: check assemble artifactoryPublish -Partifactory_publish_contextUrl=https://repo.spring.io
-        wrapper-cache-enabled: true
-        dependencies-cache-enabled: true
-        configuration-cache-enabled: true
+    # - uses: eskatos/gradle-command-action@v1
+    #   name: gradle
+    #   env:
+    #     ORG_GRADLE_PROJECT_artifactory_publish_username: ${{secrets.ORG_GRADLE_PROJECT_ARTIFACTORY_PUBLISH_USERNAME}}
+    #     ORG_GRADLE_PROJECT_artifactory_publish_password: ${{secrets.ORG_GRADLE_PROJECT_ARTIFACTORY_PUBLISH_PASSWORD}}
+    #   with:
+    #     arguments: check assemble artifactoryPublish -Partifactory_publish_contextUrl=https://repo.spring.io
+    #     wrapper-cache-enabled: true
+    #     dependencies-cache-enabled: true
+    #     configuration-cache-enabled: true
     - uses: avakar/tag-and-release@v1
       name: tag
       # if: steps.version-type.outputs.issnapshot == 'false' && steps.version-type.outputs.isunknown == 'false'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - "[0-9].[0-9]+.x"
+      - gha-publishTag #for testing purposes
 jobs:
   checks:
     name: publication

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,6 +60,6 @@ jobs:
         tag_name: "v${{ steps.read-version.outputs.value }}"
         draft: true
         prerelease: ${{ steps.version-type.outputs.isrelease == 'false' }}
-        body: "Reactor Addons `${{ steps.read-version.outputs.value }}` is part of the **`` release train (codename ``)**. TODO"
+        body: "Reactor Addons `${{ steps.read-version.outputs.value }}` is part of the **`RELEASETRAIN` release train (codename `CODENAME`)**. TODO"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,3 +52,13 @@ jobs:
         wrapper-cache-enabled: true
         dependencies-cache-enabled: true
         configuration-cache-enabled: true
+    - uses: avakar/tag-and-release@v1
+      name: tag
+      # if: steps.version-type.outputs.issnapshot == 'false' && steps.version-type.outputs.isunknown == 'false'
+      if: steps.version-type.outputs.isunknown == 'false' #temp for test
+      with:
+        tag_name: "v${{ steps.read-version.outputs.value }}"
+        draft: true
+        prerelease: ${{ steps.version-type.outputs.isrelease == 'false' }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - master
       - "[0-9].[0-9]+.x"
-      - gha-publishTag #for testing purposes
 jobs:
   checks:
     name: publication
@@ -42,20 +41,19 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 8
-    # - uses: eskatos/gradle-command-action@v1
-    #   name: gradle
-    #   env:
-    #     ORG_GRADLE_PROJECT_artifactory_publish_username: ${{secrets.ORG_GRADLE_PROJECT_ARTIFACTORY_PUBLISH_USERNAME}}
-    #     ORG_GRADLE_PROJECT_artifactory_publish_password: ${{secrets.ORG_GRADLE_PROJECT_ARTIFACTORY_PUBLISH_PASSWORD}}
-    #   with:
-    #     arguments: check assemble artifactoryPublish -Partifactory_publish_contextUrl=https://repo.spring.io
-    #     wrapper-cache-enabled: true
-    #     dependencies-cache-enabled: true
-    #     configuration-cache-enabled: true
+    - uses: eskatos/gradle-command-action@v1
+      name: gradle
+      env:
+        ORG_GRADLE_PROJECT_artifactory_publish_username: ${{secrets.ORG_GRADLE_PROJECT_ARTIFACTORY_PUBLISH_USERNAME}}
+        ORG_GRADLE_PROJECT_artifactory_publish_password: ${{secrets.ORG_GRADLE_PROJECT_ARTIFACTORY_PUBLISH_PASSWORD}}
+      with:
+        arguments: check assemble artifactoryPublish -Partifactory_publish_contextUrl=https://repo.spring.io
+        wrapper-cache-enabled: true
+        dependencies-cache-enabled: true
+        configuration-cache-enabled: true
     - uses: avakar/tag-and-release@v1
       name: tag
-      # if: steps.version-type.outputs.issnapshot == 'false' && steps.version-type.outputs.isunknown == 'false'
-      if: steps.version-type.outputs.isunknown == 'false' #temp for test
+      if: steps.version-type.outputs.issnapshot == 'false' && steps.version-type.outputs.isunknown == 'false'
       with:
         tag_name: "v${{ steps.read-version.outputs.value }}"
         draft: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,5 +60,6 @@ jobs:
         tag_name: "v${{ steps.read-version.outputs.value }}"
         draft: true
         prerelease: ${{ steps.version-type.outputs.isrelease == 'false' }}
+        body: "Reactor Addons `${{ steps.read-version.outputs.value }}` is part of the **`` release train (codename ``)**. TODO"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=3.4.2
+version=3.3.5.BUILD-SNAPSHOT
 reactorCoreVersion=3.3.11.BUILD-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=3.3.5.BUILD-SNAPSHOT
+version=3.4.2
 reactorCoreVersion=3.3.11.BUILD-SNAPSHOT


### PR DESCRIPTION
This change reads the version from `gradle.properties` and uses regexp to interpret it, allowing the GitHub Actions workflow to determine if we're dealing with a snapshot, a pre-release or a release.

In turn, it uses the later information to automatically prepare a draft gh release for pre-releases and releases. Once the draft is manually published, it will correctly tag the commit with `vVERSION` (light tag as far as I understand, no comment but it should be fine).