### PR TITLE
GitHub Actions Release Process: signing, artifactory, sonatype

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,63 +1,110 @@
 name: publish
 on:
   push:
-    branches:
+    branches: # For branches, better to list them explicitly than regexp include
       - master
-      - "[0-9].[0-9]+.x"
+      - 3.3.x
 jobs:
-  checks:
-    name: publication
+  # General job notes: we DON'T want to cancel any previous runs, especially in the case of a "back to snapshots" build right after a release push
+  prepare:
+    # Notes on prepare: this job has no access to secrets, only github token. As a result, all non-core actions are centralized here
+    # This includes the tagging and drafting of release notes. Still, when possible we favor plain run of gradle tasks
+    name: prepare
     runs-on: ubuntu-latest
+    outputs:
+      versionType: ${{ steps.version.outputs.versionType }}
     steps:
-    # we DON'T want to cancel previous runs, especially in the case of a "back to snapshots" build right after a release push
     - uses: actions/checkout@v2
-    - uses: christian-draeger/read-properties@1.0.1
-      name: read version
-      id: read-version
+    - name: setup java
+      uses: actions/setup-java@v1
       with:
-        path: './gradle.properties'
-        property: 'version'
-    - uses: frabert/replace-string-action@v1.2
-      id: split-qualifier
-      with:
-        string: ${{ steps.read-version.outputs.value }}
-        pattern: '(\d+\.\d+\.\d+)[.-]?([\w-]*)'
-        replace-with: 'VERSION$2'
+        java-version: 8
     - name: interpret version
-      id: version-type
+      id: version
+      #we only run the qualifyVersionGha task so that no other console printing can hijack this step's output
+      #output: versionType, fullVersion
+      run: ./gradlew qualifyVersionGha
+    - name: fail-if-bad
+      if: steps.version.outputs.versionType == 'BAD'
       run: |
-          echo "::set-output name=issnapshot::${{ steps.split-qualifier.outputs.replaced == 'VERSIONSNAPSHOT' || steps.split-qualifier.outputs.replaced == 'VERSIONBUILD-SNAPSHOT'  }}"
-          echo "::set-output name=isprerelease::${{ startsWith(steps.split-qualifier.outputs.replaced,'VERSIONRC') || startsWith(steps.split-qualifier.outputs.replaced,'VERSIONM')  }}"
-          echo "::set-output name=isrelease::${{ steps.split-qualifier.outputs.replaced == 'VERSIONRELEASE' || steps.split-qualifier.outputs.replaced == 'VERSION'  }}"
-          echo "::set-output name=isunknown::${{ startsWith(steps.split-qualifier.outputs.replaced,'VERSION') != true  }}"
-    - name: validate version interpretation
-      if: steps.version-type.outputs.isunknown == 'true'
-      run: |
-          echo "Couldn't classify version"
-          echo "${{ steps.read-version.outputs.value }}"
-          echo "${{ toJson(steps.split-qualifier.outputs) }}"
-          echo "${{ toJson(steps.version-type.outputs) }}"
+          echo "Couldn't classify version ${{ steps.version.outputs.fullVersion }}, see warning in above step"
           return 1
+    - name: run checks
+      id: checks
+      run: ./gradlew check
+    - name: tag
+      uses: avakar/tag-and-release@v1
+      if: steps.version.outputs.versionType == 'RELEASE' || steps.gradle.outputs.versionType == 'MILESTONE'
+      with:
+        tag_name: "v${{ steps.version.outputs.fullVersion }}"
+        draft: true
+        prerelease: ${{ steps.version.outputs.versionType == 'MILESTONE' }}
+        body: "Reactor Addons `${{ steps.version.outputs.fullVersion }}` is part of the **`RELEASETRAIN` release train (codename `CODENAME`)**. TODO"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  #deploy the snapshot artifacts to Artifactory
+  deploySnapshot:
+    name: deploySnapshot
+    runs-on: ubuntu-latest
+    needs: prepare
+    if: needs.prepare.outputs.versionType == 'SNAPSHOT'
+    environment: snapshots
+    steps:
+    - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
       with:
         java-version: 8
-    - uses: eskatos/gradle-command-action@v1
-      name: gradle
+    - name: deploy
       env:
-        ORG_GRADLE_PROJECT_artifactory_publish_username: ${{secrets.ORG_GRADLE_PROJECT_ARTIFACTORY_PUBLISH_USERNAME}}
-        ORG_GRADLE_PROJECT_artifactory_publish_password: ${{secrets.ORG_GRADLE_PROJECT_ARTIFACTORY_PUBLISH_PASSWORD}}
+        ORG_GRADLE_PROJECT_artifactory_publish_username: ${{secrets.ARTIFACTORY_SNAPSHOT_USERNAME}}
+        ORG_GRADLE_PROJECT_artifactory_publish_password: ${{secrets.ARTIFACTORY_PASSWORD}}
+      run: |
+          ./gradlew assemble artifactoryPublish -Partifactory_publish_contextUrl=https://repo.spring.io -Partifactory_publish_repoKey=libs-snapshot-local
+
+  #sign the milestone artifacts and deploy them to Artifactory
+  deployMilestone:
+    name: deployMilestone
+    runs-on: ubuntu-latest
+    needs: prepare
+    if: needs.prepare.outputs.versionType == 'MILESTONE'
+    environment: releases
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v1
       with:
-        arguments: check assemble artifactoryPublish -Partifactory_publish_contextUrl=https://repo.spring.io
-        wrapper-cache-enabled: true
-        dependencies-cache-enabled: true
-        configuration-cache-enabled: true
-    - uses: avakar/tag-and-release@v1
-      name: tag
-      if: steps.version-type.outputs.issnapshot == 'false' && steps.version-type.outputs.isunknown == 'false'
-      with:
-        tag_name: "v${{ steps.read-version.outputs.value }}"
-        draft: true
-        prerelease: ${{ steps.version-type.outputs.isrelease == 'false' }}
-        body: "Reactor Addons `${{ steps.read-version.outputs.value }}` is part of the **`RELEASETRAIN` release train (codename `CODENAME`)**. TODO"
+        java-version: 8
+    - name: deploy
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ORG_GRADLE_PROJECT_artifactory_publish_username: ${{secrets.ARTIFACTORY_USERNAME}}
+        ORG_GRADLE_PROJECT_artifactory_publish_password: ${{secrets.ARTIFACTORY_PASSWORD}}
+        ORG_GRADLE_PROJECT_signingKey: ${{secrets.SIGNING_KEY}}
+        ORG_GRADLE_PROJECT_signingPassword: ${{secrets.SIGNING_PASSPHRASE}}
+      run: |
+          ./gradlew assemble sign artifactoryPublish -Partifactory_publish_contextUrl=https://repo.spring.io -Partifactory_publish_repoKey=libs-milestone-local
+
+  #sign the release artifacts and deploy them to Artifactory
+  deployRelease:
+    name: deployRelease
+    runs-on: ubuntu-latest
+    needs: prepare
+    if: needs.prepare.outputs.versionType == 'RELEASE'
+    environment: releases
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - name: deploy
+      env:
+        ORG_GRADLE_PROJECT_artifactory_publish_username: ${{secrets.ARTIFACTORY_USERNAME}}
+        ORG_GRADLE_PROJECT_artifactory_publish_password: ${{secrets.ARTIFACTORY_PASSWORD}}
+        ORG_GRADLE_PROJECT_signingKey: ${{secrets.SIGNING_KEY}}
+        ORG_GRADLE_PROJECT_signingPassword: ${{secrets.SIGNING_PASSPHRASE}}
+        ORG_GRADLE_PROJECT_sonatypeUsername: ${{secrets.SONATYPE_USERNAME}}
+        ORG_GRADLE_PROJECT_sonatypePassword: ${{secrets.SONATYPE_PASSWORD}}
+      run: |
+          ./gradlew assemble sign artifactoryPublish -Partifactory_publish_contextUrl=https://repo.spring.io  -Partifactory_publish_repoKey=libs-release-local publishMavenJavaPublicationToSonatypeRepository
+
+# For Gradle configuration of signing, see https://docs.gradle.org/current/userguide/signing_plugin.html#sec:in-memory-keys
+# publishMavenJavaPublicationToSonatypeRepository only sends to a staging repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,11 +6,12 @@ on:
       - 3.3.x
 jobs:
   # General job notes: we DON'T want to cancel any previous runs, especially in the case of a "back to snapshots" build right after a release push
+  # We specify the ubuntu version to minimize the chances we have to deal with a migration during a release
   prepare:
     # Notes on prepare: this job has no access to secrets, only github token. As a result, all non-core actions are centralized here
     # This includes the tagging and drafting of release notes. Still, when possible we favor plain run of gradle tasks
     name: prepare
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       versionType: ${{ steps.version.outputs.versionType }}
     steps:
@@ -23,12 +24,8 @@ jobs:
       id: version
       #we only run the qualifyVersionGha task so that no other console printing can hijack this step's output
       #output: versionType, fullVersion
+      #fails if versionType is BAD, which interrupts the workflow
       run: ./gradlew qualifyVersionGha
-    - name: fail-if-bad
-      if: steps.version.outputs.versionType == 'BAD'
-      run: |
-          echo "Couldn't classify version ${{ steps.version.outputs.fullVersion }}, see warning in above step"
-          return 1
     - name: run checks
       id: checks
       run: ./gradlew check
@@ -46,7 +43,7 @@ jobs:
   #deploy the snapshot artifacts to Artifactory
   deploySnapshot:
     name: deploySnapshot
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: prepare
     if: needs.prepare.outputs.versionType == 'SNAPSHOT'
     environment: snapshots
@@ -65,7 +62,7 @@ jobs:
   #sign the milestone artifacts and deploy them to Artifactory
   deployMilestone:
     name: deployMilestone
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: prepare
     if: needs.prepare.outputs.versionType == 'MILESTONE'
     environment: releases
@@ -86,7 +83,7 @@ jobs:
   #sign the release artifacts and deploy them to Artifactory
   deployRelease:
     name: deployRelease
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: prepare
     if: needs.prepare.outputs.versionType == 'RELEASE'
     environment: releases

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,15 +30,15 @@ jobs:
       id: checks
       run: ./gradlew check
     - name: tag
-      uses: avakar/tag-and-release@v1
-      if: steps.version.outputs.versionType == 'RELEASE' || steps.gradle.outputs.versionType == 'MILESTONE'
+      if: steps.version.outputs.versionType == 'RELEASE' || steps.version.outputs.versionType == 'MILESTONE'
       with:
         tag_name: "v${{ steps.version.outputs.fullVersion }}"
-        draft: true
-        prerelease: ${{ steps.version.outputs.versionType == 'MILESTONE' }}
-        body: "Reactor Addons `${{ steps.version.outputs.fullVersion }}` is part of the **`RELEASETRAIN` release train (codename `CODENAME`)**. TODO"
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        tag_comment: "Release version ${{ steps.version.outputs.fullVersion }}"
+      run: |
+        git config --local user.name 'reactorbot'
+        git config --local user.email '32325210+reactorbot@users.noreply.github.com'
+        git tag -m "${{ tag_comment }}" ${{ tag_name }} ${{ github.sha }}
+        git push --tags
 
   #deploy the snapshot artifacts to Artifactory
   deploySnapshot:

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -107,7 +107,7 @@ if (rootProject.hasProperty("artifactory_publish_password")) {
 			contextUrl = "${artifactory_publish_contextUrl}"
 			publish {
 				repository {
-					repoKey = repoKeyFor(p)
+					repoKey = "${artifactory_publish_repoKey}"
 					username = "${artifactory_publish_username}"
 					password = "${artifactory_publish_password}"
 				}
@@ -121,22 +121,4 @@ if (rootProject.hasProperty("artifactory_publish_password")) {
 			}
 		}
 	}
-}
-
-static def repoKeyFor(p) {
-	def repos = [
-			// New scheme
-			(~/^\d+\.\d+\.\d+$/) : "libs-release-local",
-			(~/^\d+\.\d+\.\d+-SNAPSHOT$/) : "libs-snapshot-local",
-			(~/^\d+\.\d+\.\d+-M\d+$/) : "libs-milestone-local",
-			(~/^\d+\.\d+\.\d+-RC\d+$/) : "libs-milestone-local",
-			// Old scheme
-			(~/^\d+\.\d+\.\d+\.RELEASE$/) : "libs-release-local",
-			(~/^\d+\.\d+\.\d+\.BUILD-SNAPSHOT$/) : "libs-snapshot-local",
-			(~/^\d+\.\d+\.\d+\.M\d+$/) : "libs-milestone-local",
-			(~/^\d+\.\d+\.\d+\.RC\d+$/) : "libs-milestone-local",
-			// Test
-			(~/^\d+\.\d+\.\d+-.+-SNAPSHOT$/) : "libs-snapshot-local",
-	]
-	return repos.find {e -> p.version =~ e.key}.value
 }

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -113,7 +113,7 @@ if (rootProject.hasProperty("artifactory_publish_password")) {
 				}
 			}
 			clientConfig.setIncludeEnvVars(false)
-			clientConfig.info.setBuildName('Reactor - GitHub Actions - Addons')
+			clientConfig.info.setBuildName('Reactor - Addons')
 			clientConfig.info.setBuildNumber(buildNumber)
 			if (System.getenv("GITHUB_ACTIONS") == "true") {
 				clientConfig.info.setBuildUrl(System.getenv("GITHUB_SERVER_URL") + "/" + System.getenv("GITHUB_REPOSITORY") + "/actions/runs/" + System.getenv("GITHUB_RUN_ID"))

--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -55,12 +55,12 @@ task qualifyVersionGha() {
 	doLast {
 		def versionType = qualifyVersion("$version")
 
-		if (versionType == "BAD") {
-			println "::warning ::Unable to parse $version to a VersionNumber with recognizable qualifier"
-		}
-
 		println "::set-output name=versionType::$versionType"
 		println "::set-output name=fullVersion::$version"
+		if (versionType == "BAD") {
+			println "::error ::Unable to parse $version to a VersionNumber with recognizable qualifier"
+			throw new TaskExecutionException(tasks.getByName("qualifyVersionGha"), new IllegalArgumentException("Unable to parse $version to a VersionNumber with recognizable qualifier"))
+		}
 	}
 }
 

--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -66,11 +66,13 @@ task qualifyVersionGha() {
 
 publishing {
 	publications {
+		extras(MavenPublication) {
+//			other project-specific artifacts must be added to this publication, in each project's builds
+		}
 		mavenJava(MavenPublication) {
 			from components.java
 			artifact sourcesJar
 			artifact javadocJar
-			//other project-specific artifacts must be added in each project's builds
 
 			pom {
 				afterEvaluate {
@@ -152,7 +154,7 @@ if (rootProject.hasProperty("artifactory_publish_password")) {
 	apply plugin: "com.jfrog.artifactory"
 
 	artifactoryPublish {
-		publications(publishing.publications.mavenJava)
+		publications(publishing.publications.mavenJava, publishing.publications.extras)
 	}
 }
 

--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -1,3 +1,5 @@
+import org.gradle.util.VersionNumber
+
 /*
  * Copyright (c) 2011-2017 Pivotal Software Inc, All Rights Reserved.
  *
@@ -18,7 +20,7 @@
 
 apply plugin: 'propdeps-maven'
 apply plugin: 'maven-publish'
-apply plugin: 'com.jfrog.artifactory'
+//we also conditionally apply artifactory and signing plugins below
 
 jar {
 	manifest.attributes["Created-By"] = "${System.getProperty("java.version")} (${System.getProperty("java.specification.vendor")})"
@@ -34,6 +36,32 @@ task sourcesJar(type: Jar) {
 task javadocJar(type: Jar) {
 	archiveClassifier.set('javadoc')
 	from javadoc
+}
+
+static def qualifyVersion(String v) {
+	def versionNumber = VersionNumber.parse(v)
+
+	if (versionNumber == VersionNumber.UNKNOWN) return "BAD";
+
+	if (versionNumber.qualifier == null || versionNumber.qualifier.size() == 0) return "RELEASE" //new scheme
+	if (versionNumber.qualifier == "RELEASE") return "RELEASE" //old scheme
+	if (versionNumber.qualifier.matches("(?:M|RC)\\d+")) return "MILESTONE"
+	if (versionNumber.qualifier == "SNAPSHOT" || versionNumber.qualifier == "BUILD-SNAPSHOT") return "SNAPSHOT"
+
+	return "BAD"
+}
+
+task qualifyVersionGha() {
+	doLast {
+		def versionType = qualifyVersion("$version")
+
+		if (versionType == "BAD") {
+			println "::warning ::Unable to parse $version to a VersionNumber with recognizable qualifier"
+		}
+
+		println "::set-output name=versionType::$versionType"
+		println "::set-output name=fullVersion::$version"
+	}
 }
 
 publishing {
@@ -106,10 +134,41 @@ publishing {
 			}
 		}
 	}
+	if (qualifyVersion("$version") == "RELEASE") {
+		repositories {
+			maven {
+				name = "sonatype"
+				url = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2"
+				credentials {
+					username findProperty("sonatypeUsername")
+					password findProperty("sonatypePassword")
+				}
+			}
+		}
+	}
 }
 
-artifactoryPublish {
-	//don't activate the onlyIf clause below yet, so that Bamboo builds will publish stuff...
-	//onlyIf { project.hasProperty("artifactory_publish_password")") }
-	publications(publishing.publications.mavenJava)
+if (rootProject.hasProperty("artifactory_publish_password")) {
+	apply plugin: "com.jfrog.artifactory"
+
+	artifactoryPublish {
+		publications(publishing.publications.mavenJava)
+	}
+}
+
+if (qualifyVersion("$version") in ["RELEASE", "MILESTONE"]) {
+	apply plugin: 'signing'
+
+	signing {
+		//requiring signature if there is a publish task that is not to MavenLocal
+		required {  gradle.taskGraph.allTasks.any { it.name.toLowerCase().contains("publish")	&& !it.name.contains("MavenLocal") } }
+		def signingKey = findProperty("signingKey")
+		def signingPassword = findProperty("signingPassword")
+
+		useInMemoryPgpKeys(signingKey, signingPassword)
+
+		afterEvaluate {
+			sign publishing.publications.mavenJava
+		}
+	}
 }


### PR DESCRIPTION
This commit refactors the release workflow, defining some tasks and
helper methods in the setup.gradle file and reworking the publish.yml
workflow into 4 jobs, 3 of which are conditional and depend on a GitHub
Environment.

This is according to reactor/reactor#694.

Notably:
 - Add a function to qualify a version number as one of RELEASE,
 MILESTONE, SNAPSHOT or BAD
 - Add a GitHub Actions oriented task, `qualifyVersionGha`, which
 produces gha step output for the current project version. `versionType`
 is an application of the above function and `fullVersion` is the plain
 project's `version`
 - Activate the JFrog Artifactory plugin only if a password is defined
 (including in subprojects)
 - Add the `signing` plugin, activated only if a signing key is defined,
   requiring that signing be performed if a publish task is invoked
 - Add a Maven publication repository if Sonatype OSS credentials are
   defined
