### PR TITLE
GitHub Actions Release: Back to single publication, fix empty pom

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
     branches: # For branches, better to list them explicitly than regexp include
       - master
       - 3.3.x
+      - 254-backToSinglePublication
 jobs:
   # General job notes: we DON'T want to cancel any previous runs, especially in the case of a "back to snapshots" build right after a release push
   # We specify the ubuntu version to minimize the chances we have to deal with a migration during a release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,6 @@ on:
     branches: # For branches, better to list them explicitly than regexp include
       - master
       - 3.3.x
-      - 254-backToSinglePublication
 jobs:
   # General job notes: we DON'T want to cancel any previous runs, especially in the case of a "back to snapshots" build right after a release push
   # We specify the ubuntu version to minimize the chances we have to deal with a migration during a release

--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -65,14 +65,29 @@ task qualifyVersionGha() {
 }
 
 publishing {
-	publications {
-		extras(MavenPublication) {
-//			other project-specific artifacts must be added to this publication, in each project's builds
+	repositories {
+		maven {
+			name = "mock"
+			url = "${rootProject.buildDir}/mockRepo"
 		}
+		if (qualifyVersion("$version") == "RELEASE") {
+			maven {
+				name = "sonatype"
+				url = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2"
+				credentials {
+					username findProperty("sonatypeUsername")
+					password findProperty("sonatypePassword")
+				}
+			}
+		}
+	}
+
+	publications {
 		mavenJava(MavenPublication) {
 			from components.java
 			artifact sourcesJar
 			artifact javadocJar
+			//consider adding extra artifacts here, conditionally on submodule's name and perhaps in an afterEvaluate block
 
 			pom {
 				afterEvaluate {
@@ -136,29 +151,17 @@ publishing {
 			}
 		}
 	}
-	if (qualifyVersion("$version") == "RELEASE") {
-		repositories {
-			maven {
-				name = "sonatype"
-				url = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2"
-				credentials {
-					username findProperty("sonatypeUsername")
-					password findProperty("sonatypePassword")
-				}
-			}
-		}
-	}
 }
 
 if (rootProject.hasProperty("artifactory_publish_password")) {
 	apply plugin: "com.jfrog.artifactory"
 
 	artifactoryPublish {
-		publications(publishing.publications.mavenJava, publishing.publications.extras)
+		publications(publishing.publications.mavenJava)
 	}
 }
 
-if (qualifyVersion("$version") in ["RELEASE", "MILESTONE"]) {
+if (qualifyVersion("$version") in ["RELEASE", "MILESTONE"] || rootProject.hasProperty("forceSigning")) {
 	apply plugin: 'signing'
 
 	signing {


### PR DESCRIPTION
This commit removes the extras publication, which caused issues
in the distribution of the pom.xml.

It also adds a mock maven repository and a `-PforceSigning` option
for debugging purposes.

Fixes #254.