### PR TITLE
[chores] Copyright: Correct start year for all files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/doc.gradle
+++ b/gradle/doc.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/setup.gradle
+++ b/gradle/setup.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-adapter/src/main/java/reactor/adapter/akka/ActorScheduler.java
+++ b/reactor-adapter/src/main/java/reactor/adapter/akka/ActorScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-adapter/src/main/java/reactor/adapter/rxjava/RxJava2Schedulers.java
+++ b/reactor-adapter/src/main/java/reactor/adapter/rxjava/RxJava2Schedulers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-adapter/src/main/java/reactor/adapter/rxjava/RxJava3Adapter.java
+++ b/reactor-adapter/src/main/java/reactor/adapter/rxjava/RxJava3Adapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-adapter/src/main/java/reactor/adapter/rxjava/RxJava3Scheduler.java
+++ b/reactor-adapter/src/main/java/reactor/adapter/rxjava/RxJava3Scheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-adapter/src/main/kotlin/reactor/adapter/rxjava/RxJava2AdapterExt.kt
+++ b/reactor-adapter/src/main/kotlin/reactor/adapter/rxjava/RxJava2AdapterExt.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018-2019 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.adapter.rxjava
 
 import io.reactivex.BackpressureStrategy

--- a/reactor-adapter/src/main/kotlin/reactor/adapter/rxjava/RxJava2AdapterExt.kt
+++ b/reactor-adapter/src/main/kotlin/reactor/adapter/rxjava/RxJava2AdapterExt.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-adapter/src/test/java/reactor/adapter/akka/ActorAdapterTest.java
+++ b/reactor-adapter/src/test/java/reactor/adapter/akka/ActorAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-adapter/src/test/java/reactor/adapter/rxjava/RxJava2SchedulersTest.java
+++ b/reactor-adapter/src/test/java/reactor/adapter/rxjava/RxJava2SchedulersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2019-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-adapter/src/test/java/reactor/adapter/rxjava/RxJava3AdapterTest.java
+++ b/reactor-adapter/src/test/java/reactor/adapter/rxjava/RxJava3AdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2020-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/bool/BooleanUtils.java
+++ b/reactor-extra/src/main/java/reactor/bool/BooleanUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/cache/CacheFlux.java
+++ b/reactor-extra/src/main/java/reactor/cache/CacheFlux.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/cache/CacheMono.java
+++ b/reactor-extra/src/main/java/reactor/cache/CacheMono.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/extra/processor/EventLoopProcessor.java
+++ b/reactor-extra/src/main/java/reactor/extra/processor/EventLoopProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/extra/processor/RingBuffer.java
+++ b/reactor-extra/src/main/java/reactor/extra/processor/RingBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/extra/processor/TopicProcessor.java
+++ b/reactor-extra/src/main/java/reactor/extra/processor/TopicProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/extra/processor/WaitStrategy.java
+++ b/reactor-extra/src/main/java/reactor/extra/processor/WaitStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/extra/processor/WorkQueueProcessor.java
+++ b/reactor-extra/src/main/java/reactor/extra/processor/WorkQueueProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/function/Consumer3.java
+++ b/reactor-extra/src/main/java/reactor/function/Consumer3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/function/Consumer4.java
+++ b/reactor-extra/src/main/java/reactor/function/Consumer4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/function/Consumer5.java
+++ b/reactor-extra/src/main/java/reactor/function/Consumer5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/function/Consumer6.java
+++ b/reactor-extra/src/main/java/reactor/function/Consumer6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/function/Consumer7.java
+++ b/reactor-extra/src/main/java/reactor/function/Consumer7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/function/Consumer8.java
+++ b/reactor-extra/src/main/java/reactor/function/Consumer8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/function/Function3.java
+++ b/reactor-extra/src/main/java/reactor/function/Function3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/function/Function4.java
+++ b/reactor-extra/src/main/java/reactor/function/Function4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/function/Function5.java
+++ b/reactor-extra/src/main/java/reactor/function/Function5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/function/Function6.java
+++ b/reactor-extra/src/main/java/reactor/function/Function6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/function/Function7.java
+++ b/reactor-extra/src/main/java/reactor/function/Function7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/function/Function8.java
+++ b/reactor-extra/src/main/java/reactor/function/Function8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/function/Predicate3.java
+++ b/reactor-extra/src/main/java/reactor/function/Predicate3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/function/Predicate4.java
+++ b/reactor-extra/src/main/java/reactor/function/Predicate4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/function/Predicate5.java
+++ b/reactor-extra/src/main/java/reactor/function/Predicate5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/function/Predicate6.java
+++ b/reactor-extra/src/main/java/reactor/function/Predicate6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/function/Predicate7.java
+++ b/reactor-extra/src/main/java/reactor/function/Predicate7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/function/Predicate8.java
+++ b/reactor-extra/src/main/java/reactor/function/Predicate8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/function/TupleUtils.java
+++ b/reactor-extra/src/main/java/reactor/function/TupleUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/math/MathFlux.java
+++ b/reactor-extra/src/main/java/reactor/math/MathFlux.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/math/MathSubscriber.java
+++ b/reactor-extra/src/main/java/reactor/math/MathSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/math/MonoAverageBigDecimal.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoAverageBigDecimal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/math/MonoAverageBigInteger.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoAverageBigInteger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/math/MonoAverageDouble.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoAverageDouble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/math/MonoAverageFloat.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoAverageFloat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/math/MonoFromFluxOperator.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoFromFluxOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/math/MonoMinMax.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoMinMax.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/math/MonoSumBigDecimal.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoSumBigDecimal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/math/MonoSumBigInteger.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoSumBigInteger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/math/MonoSumDouble.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoSumDouble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/math/MonoSumFloat.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoSumFloat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/math/MonoSumInt.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoSumInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/math/MonoSumLong.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoSumLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/retry/AbstractRetry.java
+++ b/reactor-extra/src/main/java/reactor/retry/AbstractRetry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/retry/Backoff.java
+++ b/reactor-extra/src/main/java/reactor/retry/Backoff.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/retry/BackoffDelay.java
+++ b/reactor-extra/src/main/java/reactor/retry/BackoffDelay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/retry/DefaultContext.java
+++ b/reactor-extra/src/main/java/reactor/retry/DefaultContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/retry/DefaultRepeat.java
+++ b/reactor-extra/src/main/java/reactor/retry/DefaultRepeat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/retry/DefaultRetry.java
+++ b/reactor-extra/src/main/java/reactor/retry/DefaultRetry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/retry/IterationContext.java
+++ b/reactor-extra/src/main/java/reactor/retry/IterationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/retry/Jitter.java
+++ b/reactor-extra/src/main/java/reactor/retry/Jitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/retry/RandomJitter.java
+++ b/reactor-extra/src/main/java/reactor/retry/RandomJitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/retry/RandomJitter.java
+++ b/reactor-extra/src/main/java/reactor/retry/RandomJitter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.retry;
 
 import java.time.Duration;

--- a/reactor-extra/src/main/java/reactor/retry/Repeat.java
+++ b/reactor-extra/src/main/java/reactor/retry/Repeat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/retry/RepeatContext.java
+++ b/reactor-extra/src/main/java/reactor/retry/RepeatContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/retry/Retry.java
+++ b/reactor-extra/src/main/java/reactor/retry/Retry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/retry/RetryContext.java
+++ b/reactor-extra/src/main/java/reactor/retry/RetryContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/retry/RetryExhaustedException.java
+++ b/reactor-extra/src/main/java/reactor/retry/RetryExhaustedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/scheduler/clock/SchedulerClock.java
+++ b/reactor-extra/src/main/java/reactor/scheduler/clock/SchedulerClock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/scheduler/forkjoin/ForkJoinPoolScheduler.java
+++ b/reactor-extra/src/main/java/reactor/scheduler/forkjoin/ForkJoinPoolScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/swing/SwingScheduler.java
+++ b/reactor-extra/src/main/java/reactor/swing/SwingScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/java/reactor/swing/SwtScheduler.java
+++ b/reactor-extra/src/main/java/reactor/swing/SwtScheduler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/main/kotlin/reactor/bool/BooleanMonoExtensions.kt
+++ b/reactor-extra/src/main/kotlin/reactor/bool/BooleanMonoExtensions.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.bool
 
 import reactor.core.publisher.Mono

--- a/reactor-extra/src/main/kotlin/reactor/math/MathFluxExtensions.kt
+++ b/reactor-extra/src/main/kotlin/reactor/math/MathFluxExtensions.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.math
 
 import reactor.core.publisher.Flux

--- a/reactor-extra/src/main/kotlin/reactor/retry/RepeatExtensions.kt
+++ b/reactor-extra/src/main/kotlin/reactor/retry/RepeatExtensions.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.retry
 
 import reactor.core.publisher.Flux

--- a/reactor-extra/src/main/kotlin/reactor/retry/RetryExtensions.kt
+++ b/reactor-extra/src/main/kotlin/reactor/retry/RetryExtensions.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.retry
 
 import reactor.core.publisher.Flux

--- a/reactor-extra/src/main/kotlin/reactor/swing/SwtSchedulerExtensions.kt
+++ b/reactor-extra/src/main/kotlin/reactor/swing/SwtSchedulerExtensions.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.swing
 
 import org.eclipse.swt.widgets.Display

--- a/reactor-extra/src/test/java/reactor/bool/BooleanUtilsTest.java
+++ b/reactor-extra/src/test/java/reactor/bool/BooleanUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/bool/BooleanUtilsTest.java
+++ b/reactor-extra/src/test/java/reactor/bool/BooleanUtilsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.bool;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/reactor-extra/src/test/java/reactor/cache/CacheFluxTest.java
+++ b/reactor-extra/src/test/java/reactor/cache/CacheFluxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2020 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/cache/CacheFluxTest.java
+++ b/reactor-extra/src/test/java/reactor/cache/CacheFluxTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017-2020 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.cache;
 
 import java.util.Arrays;

--- a/reactor-extra/src/test/java/reactor/cache/CacheMonoTest.java
+++ b/reactor-extra/src/test/java/reactor/cache/CacheMonoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2020 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/cache/CacheMonoTest.java
+++ b/reactor-extra/src/test/java/reactor/cache/CacheMonoTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017-2020 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.cache;
 
 import java.time.Duration;

--- a/reactor-extra/src/test/java/reactor/extra/processor/AbstractFluxVerification.java
+++ b/reactor-extra/src/test/java/reactor/extra/processor/AbstractFluxVerification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/extra/processor/AbstractProcessorVerification.java
+++ b/reactor-extra/src/test/java/reactor/extra/processor/AbstractProcessorVerification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/extra/processor/BurstyWorkQueueProcessorTests.java
+++ b/reactor-extra/src/test/java/reactor/extra/processor/BurstyWorkQueueProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/extra/processor/CombinationTests.java
+++ b/reactor-extra/src/test/java/reactor/extra/processor/CombinationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/extra/processor/ConsistentProcessorTests.java
+++ b/reactor-extra/src/test/java/reactor/extra/processor/ConsistentProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/extra/processor/EventLoopProcessorTest.java
+++ b/reactor-extra/src/test/java/reactor/extra/processor/EventLoopProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/extra/processor/FluxWithProcessorVerification.java
+++ b/reactor-extra/src/test/java/reactor/extra/processor/FluxWithProcessorVerification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/extra/processor/TopicProcessorTest.java
+++ b/reactor-extra/src/test/java/reactor/extra/processor/TopicProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/extra/processor/TopicProcessorVerification.java
+++ b/reactor-extra/src/test/java/reactor/extra/processor/TopicProcessorVerification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/extra/processor/WorkQueueProcessorTest.java
+++ b/reactor-extra/src/test/java/reactor/extra/processor/WorkQueueProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/extra/processor/WorkQueueProcessorVerification.java
+++ b/reactor-extra/src/test/java/reactor/extra/processor/WorkQueueProcessorVerification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/function/TupleUtilsTest.java
+++ b/reactor-extra/src/test/java/reactor/function/TupleUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/math/ReactorMathTests.java
+++ b/reactor-extra/src/test/java/reactor/math/ReactorMathTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/retry/AbstractRetryTest.java
+++ b/reactor-extra/src/test/java/reactor/retry/AbstractRetryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/retry/AbstractRetryTest.java
+++ b/reactor-extra/src/test/java/reactor/retry/AbstractRetryTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.retry;
 
 import org.junit.Test;

--- a/reactor-extra/src/test/java/reactor/retry/BackoffDelayTest.java
+++ b/reactor-extra/src/test/java/reactor/retry/BackoffDelayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/retry/BackoffDelayTest.java
+++ b/reactor-extra/src/test/java/reactor/retry/BackoffDelayTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.retry;
 
 import java.time.Duration;

--- a/reactor-extra/src/test/java/reactor/retry/BackoffTest.java
+++ b/reactor-extra/src/test/java/reactor/retry/BackoffTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/retry/BackoffTest.java
+++ b/reactor-extra/src/test/java/reactor/retry/BackoffTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017-2019 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.retry;
 
 import org.junit.Test;

--- a/reactor-extra/src/test/java/reactor/retry/DefaultRepeatTest.java
+++ b/reactor-extra/src/test/java/reactor/retry/DefaultRepeatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2018 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/retry/DefaultRepeatTest.java
+++ b/reactor-extra/src/test/java/reactor/retry/DefaultRepeatTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017-2018 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.retry;
 
 import java.time.Duration;

--- a/reactor-extra/src/test/java/reactor/retry/DefaultRetryTest.java
+++ b/reactor-extra/src/test/java/reactor/retry/DefaultRetryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2018 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/retry/DefaultRetryTest.java
+++ b/reactor-extra/src/test/java/reactor/retry/DefaultRetryTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017-2018 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.retry;
 
 import java.time.Duration;

--- a/reactor-extra/src/test/java/reactor/retry/RandomJitterTest.java
+++ b/reactor-extra/src/test/java/reactor/retry/RandomJitterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/retry/RandomJitterTest.java
+++ b/reactor-extra/src/test/java/reactor/retry/RandomJitterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.retry;
 
 import java.time.Duration;

--- a/reactor-extra/src/test/java/reactor/retry/RepeatTests.java
+++ b/reactor-extra/src/test/java/reactor/retry/RepeatTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/retry/RetryTestUtils.java
+++ b/reactor-extra/src/test/java/reactor/retry/RetryTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/retry/RetryTests.java
+++ b/reactor-extra/src/test/java/reactor/retry/RetryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/scheduler/clock/SchedulerClockTest.java
+++ b/reactor-extra/src/test/java/reactor/scheduler/clock/SchedulerClockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/scheduler/clock/SchedulerClockTest.java
+++ b/reactor-extra/src/test/java/reactor/scheduler/clock/SchedulerClockTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2017 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package reactor.scheduler.clock;
 
 import java.time.Duration;

--- a/reactor-extra/src/test/java/reactor/scheduler/forkjoin/AbstractSchedulerTest.java
+++ b/reactor-extra/src/test/java/reactor/scheduler/forkjoin/AbstractSchedulerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/scheduler/forkjoin/ForkJoinPoolSchedulerTest.java
+++ b/reactor-extra/src/test/java/reactor/scheduler/forkjoin/ForkJoinPoolSchedulerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/swing/SwingAdapterTest.java
+++ b/reactor-extra/src/test/java/reactor/swing/SwingAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/swing/SwtAdapterTest.java
+++ b/reactor-extra/src/test/java/reactor/swing/SwtAdapterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is a follow up on #258 which mistakenly harmonized all the start
dates in range to 2016. Some files have more ancient history than that,
having been transferred from older repositories.

This commit uses a mix of automation and manual process to refine the
start dates as much as possible.

As a result of automation, files that were missing the copyright notice
will have a range that reflects the git history, possibly with an end
date that is a past year.

All ranges have then been reviewed and the start year amended when it
was necessary.

This commit also manually adds copyright notices to kotlin files.

See #258.
See reactor/reactor#682.
