### PR TITLE
Deprecate CacheFlux and CacheMono, for removal in 3.6.0

### DIFF
--- a/reactor-extra/src/main/java/reactor/cache/CacheFlux.java
+++ b/reactor-extra/src/main/java/reactor/cache/CacheFlux.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ import reactor.core.publisher.Signal;
  *
  * @author Oleh Dokuka
  * @author Simon Baslé
- * @deprecated To be removed in 4.0.0. There is no great solution for generic caches, other
+ * @deprecated To be removed in 3.6.0 at the earliest. There is no great solution for generic caches, other
  * than specific implementations with async support and cache stampede protection (like Caffeine).
  * see https://github.com/reactor/reactor-addons/issues/237
  */

--- a/reactor-extra/src/main/java/reactor/cache/CacheFlux.java
+++ b/reactor-extra/src/main/java/reactor/cache/CacheFlux.java
@@ -68,7 +68,11 @@ import reactor.core.publisher.Signal;
  *
  * @author Oleh Dokuka
  * @author Simon Baslé
+ * @deprecated To be removed in 4.0.0. There is no great solution for generic caches, other
+ * than specific implementations with async support and cache stampede protection (like Caffeine).
+ * see https://github.com/reactor/reactor-addons/issues/237
  */
+@Deprecated
 public class CacheFlux {
 	
 	private CacheFlux() {

--- a/reactor-extra/src/main/java/reactor/cache/CacheMono.java
+++ b/reactor-extra/src/main/java/reactor/cache/CacheMono.java
@@ -63,7 +63,11 @@ import reactor.core.publisher.Signal;
  *
  * @author Oleh Dokuka
  * @author Simon Baslé
+ * @deprecated To be removed in 4.0.0. There is no great solution for generic caches, other
+ * than specific implementations with async support and cache stampede protection (like Caffeine).
+ * see https://github.com/reactor/reactor-addons/issues/237
  */
+@Deprecated
 public class CacheMono {
 	
 	private CacheMono() {

--- a/reactor-extra/src/main/java/reactor/cache/CacheMono.java
+++ b/reactor-extra/src/main/java/reactor/cache/CacheMono.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ import reactor.core.publisher.Signal;
  *
  * @author Oleh Dokuka
  * @author Simon Baslé
- * @deprecated To be removed in 4.0.0. There is no great solution for generic caches, other
+ * @deprecated To be removed in 3.6.0 at the earliest. There is no great solution for generic caches, other
  * than specific implementations with async support and cache stampede protection (like Caffeine).
  * see https://github.com/reactor/reactor-addons/issues/237
  */

--- a/reactor-extra/src/test/java/reactor/cache/CacheFluxTest.java
+++ b/reactor-extra/src/test/java/reactor/cache/CacheFluxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/cache/CacheFluxTest.java
+++ b/reactor-extra/src/test/java/reactor/cache/CacheFluxTest.java
@@ -42,6 +42,7 @@ import reactor.util.function.Tuples;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Deprecated
 @SuppressWarnings("unchecked")
 public class CacheFluxTest {
 

--- a/reactor-extra/src/test/java/reactor/cache/CacheMonoTest.java
+++ b/reactor-extra/src/test/java/reactor/cache/CacheMonoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactor-extra/src/test/java/reactor/cache/CacheMonoTest.java
+++ b/reactor-extra/src/test/java/reactor/cache/CacheMonoTest.java
@@ -38,6 +38,7 @@ import reactor.util.context.Context;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Deprecated
 public class CacheMonoTest {
 
 	@Test


### PR DESCRIPTION
Fixes #237.
