### PR TITLE
Fix default max backoff interval which cause long overflow

### DIFF
--- a/reactor-extra/src/main/java/reactor/retry/Backoff.java
+++ b/reactor-extra/src/main/java/reactor/retry/Backoff.java
@@ -86,7 +86,7 @@ public interface Backoff extends Function<IterationContext<?>, BackoffDelay> {
 	static Backoff exponential(Duration firstBackoff, @Nullable Duration maxBackoff, int factor, boolean basedOnPreviousValue) {
 		if (firstBackoff == null || firstBackoff.isNegative() || firstBackoff.isZero())
 			throw new IllegalArgumentException("firstBackoff must be > 0");
-		Duration maxBackoffInterval = maxBackoff != null ? maxBackoff : Duration.ofSeconds(Long.MAX_VALUE);
+		Duration maxBackoffInterval = maxBackoff != null ? maxBackoff : Duration.ofMillis(Long.MAX_VALUE);
 		if (maxBackoffInterval.compareTo(firstBackoff) < 0)
 			throw new IllegalArgumentException("maxBackoff must be >= firstBackoff");
 		if (!basedOnPreviousValue) {


### PR DESCRIPTION
## Background

https://github.com/reactor/reactor-addons/blob/3354d26af1e43e9bedc0bc631e183f7ee7c630c3/reactor-extra/src/main/java/reactor/retry/Backoff.java#L89

Now that our default max backoff interval is Duration.ofSeconds(Long.MAX_VALUE), it can cause a long overflow exception when RandomJitter tries getting high jitter bound value.


https://github.com/reactor/reactor-addons/blob/3354d26af1e43e9bedc0bc631e183f7ee7c630c3/reactor-extra/src/main/java/reactor/retry/RandomJitter.java#L106-L110
`backoff.max.minus(backoff.delay).toMillis()` exactly makes the calculation of `Long.MAX_VALUE * 1000` which throws long overflow exception.

So I guess it must be `Duration.ofMillis(Long.MAX_VALUE)`


For those who want to reproduct the exception, try below.
```java
Duration min = Duration.ofMillis(100);
Duration max = Duration.ofSeconds(Long.MAX_VALUE);
Duration delay = Duration.ofMillis(500);
BackoffDelay bd = new BackoffDelay(min, max, delay);

RandomJitter jitter = new RandomJitter(factor);

System.out.println(jitter.highJitterBound(bd, 250));
```