### PR TITLE
Deprecate Swt/Swing addons, to be removed in 3.6.0

### DIFF
--- a/reactor-extra/src/main/java/reactor/swing/SwingScheduler.java
+++ b/reactor-extra/src/main/java/reactor/swing/SwingScheduler.java
@@ -31,7 +31,7 @@ import reactor.util.context.Context;
 
 /**
  * Scheduler that runs tasks on Swing's event dispatch thread.
- * @deprecated To be removed in 3.5.0 (fast tracked). See https://github.com/reactor/reactor-addons/issues/273
+ * @deprecated To be removed in 3.6.0. See https://github.com/reactor/reactor-addons/issues/273
  */
 @Deprecated
 public final class SwingScheduler implements Scheduler {

--- a/reactor-extra/src/main/java/reactor/swing/SwingScheduler.java
+++ b/reactor-extra/src/main/java/reactor/swing/SwingScheduler.java
@@ -29,9 +29,11 @@ import reactor.core.publisher.Operators;
 import reactor.core.scheduler.Scheduler;
 import reactor.util.context.Context;
 
-/** 
- * Scheduler that runs tasks on Swing's event dispatch thread. 
+/**
+ * Scheduler that runs tasks on Swing's event dispatch thread.
+ * @deprecated To be removed exceptionally fast in 3.5.0. See https://github.com/reactor/reactor-addons/issues/273
  */
+@Deprecated
 public final class SwingScheduler implements Scheduler {
 
 	/**

--- a/reactor-extra/src/main/java/reactor/swing/SwingScheduler.java
+++ b/reactor-extra/src/main/java/reactor/swing/SwingScheduler.java
@@ -31,7 +31,7 @@ import reactor.util.context.Context;
 
 /**
  * Scheduler that runs tasks on Swing's event dispatch thread.
- * @deprecated To be removed exceptionally fast in 3.5.0. See https://github.com/reactor/reactor-addons/issues/273
+ * @deprecated To be removed in 3.5.0 (fast tracked). See https://github.com/reactor/reactor-addons/issues/273
  */
 @Deprecated
 public final class SwingScheduler implements Scheduler {

--- a/reactor-extra/src/main/java/reactor/swing/SwtScheduler.java
+++ b/reactor-extra/src/main/java/reactor/swing/SwtScheduler.java
@@ -29,7 +29,9 @@ import reactor.util.context.Context;
 
 /** 
  * Scheduler that runs tasks on Swt's event dispatch thread. 
+ * @deprecated To be removed exceptionally fast in 3.5.0. See https://github.com/reactor/reactor-addons/issues/273
  */
+@Deprecated
 public final class SwtScheduler implements Scheduler {
 
 	/**

--- a/reactor-extra/src/main/java/reactor/swing/SwtScheduler.java
+++ b/reactor-extra/src/main/java/reactor/swing/SwtScheduler.java
@@ -29,7 +29,7 @@ import reactor.util.context.Context;
 
 /** 
  * Scheduler that runs tasks on Swt's event dispatch thread. 
- * @deprecated To be removed exceptionally fast in 3.5.0. See https://github.com/reactor/reactor-addons/issues/273
+ * @deprecated To be removed in 3.5.0 (fast tracked). See https://github.com/reactor/reactor-addons/issues/273
  */
 @Deprecated
 public final class SwtScheduler implements Scheduler {

--- a/reactor-extra/src/main/java/reactor/swing/SwtScheduler.java
+++ b/reactor-extra/src/main/java/reactor/swing/SwtScheduler.java
@@ -29,7 +29,7 @@ import reactor.util.context.Context;
 
 /** 
  * Scheduler that runs tasks on Swt's event dispatch thread. 
- * @deprecated To be removed in 3.5.0 (fast tracked). See https://github.com/reactor/reactor-addons/issues/273
+ * @deprecated To be removed in 3.6.0. See https://github.com/reactor/reactor-addons/issues/273
  */
 @Deprecated
 public final class SwtScheduler implements Scheduler {

--- a/reactor-extra/src/main/java/reactor/swing/package-info.java
+++ b/reactor-extra/src/main/java/reactor/swing/package-info.java
@@ -1,5 +1,0 @@
-/**
- * @deprecated To be removed exceptionally fast in 3.5.0. See https://github.com/reactor/reactor-addons/issues/273
- */
-@Deprecated
-package reactor.swing;

--- a/reactor-extra/src/main/java/reactor/swing/package-info.java
+++ b/reactor-extra/src/main/java/reactor/swing/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * @deprecated To be removed exceptionally fast in 3.5.0. See https://github.com/reactor/reactor-addons/issues/273
+ */
+@Deprecated
+package reactor.swing;

--- a/reactor-extra/src/test/java/reactor/swing/SwingAdapterTest.java
+++ b/reactor-extra/src/test/java/reactor/swing/SwingAdapterTest.java
@@ -25,7 +25,7 @@ import reactor.test.StepVerifier;
 
 /**
  * @author Stephane Maldini
- * @deprecated To be removed exceptionally fast in 3.5.0. See https://github.com/reactor/reactor-addons/issues/273
+ * @deprecated To be removed in 3.5.0 (fast tracked). See https://github.com/reactor/reactor-addons/issues/273
  */
 @Deprecated
 public class SwingAdapterTest {

--- a/reactor-extra/src/test/java/reactor/swing/SwingAdapterTest.java
+++ b/reactor-extra/src/test/java/reactor/swing/SwingAdapterTest.java
@@ -25,7 +25,9 @@ import reactor.test.StepVerifier;
 
 /**
  * @author Stephane Maldini
+ * @deprecated To be removed exceptionally fast in 3.5.0. See https://github.com/reactor/reactor-addons/issues/273
  */
+@Deprecated
 public class SwingAdapterTest {
 
 	@Test

--- a/reactor-extra/src/test/java/reactor/swing/SwingAdapterTest.java
+++ b/reactor-extra/src/test/java/reactor/swing/SwingAdapterTest.java
@@ -25,7 +25,7 @@ import reactor.test.StepVerifier;
 
 /**
  * @author Stephane Maldini
- * @deprecated To be removed in 3.5.0 (fast tracked). See https://github.com/reactor/reactor-addons/issues/273
+ * @deprecated To be removed in 3.6.0. See https://github.com/reactor/reactor-addons/issues/273
  */
 @Deprecated
 public class SwingAdapterTest {

--- a/reactor-extra/src/test/java/reactor/swing/SwtAdapterTest.java
+++ b/reactor-extra/src/test/java/reactor/swing/SwtAdapterTest.java
@@ -25,7 +25,7 @@ import reactor.test.StepVerifier;
 
 /**
  * @author Stephane Maldini
- * @deprecated To be removed in 3.5.0 (fast tracked). See https://github.com/reactor/reactor-addons/issues/273
+ * @deprecated To be removed in 3.6.0. See https://github.com/reactor/reactor-addons/issues/273
  */
 @Deprecated
 public class SwtAdapterTest {

--- a/reactor-extra/src/test/java/reactor/swing/SwtAdapterTest.java
+++ b/reactor-extra/src/test/java/reactor/swing/SwtAdapterTest.java
@@ -25,7 +25,9 @@ import reactor.test.StepVerifier;
 
 /**
  * @author Stephane Maldini
+ * @deprecated To be removed exceptionally fast in 3.5.0. See https://github.com/reactor/reactor-addons/issues/273
  */
+@Deprecated
 public class SwtAdapterTest {
 
 	@Test

--- a/reactor-extra/src/test/java/reactor/swing/SwtAdapterTest.java
+++ b/reactor-extra/src/test/java/reactor/swing/SwtAdapterTest.java
@@ -25,7 +25,7 @@ import reactor.test.StepVerifier;
 
 /**
  * @author Stephane Maldini
- * @deprecated To be removed exceptionally fast in 3.5.0. See https://github.com/reactor/reactor-addons/issues/273
+ * @deprecated To be removed in 3.5.0 (fast tracked). See https://github.com/reactor/reactor-addons/issues/273
  */
 @Deprecated
 public class SwtAdapterTest {


### PR DESCRIPTION
This commit deprecates the SwingScheduler and SwtScheduler adapters,
which have very little usage that we can see and have the drawback
of additional dependencies and build complexity. (plus the SWT one is
using outdated SWT libraries).

Note that the corresponding kotlin extension in reactor-kotlin-extensions
will be aggressively removed in 1.2.0, while the classes in this project will
be classically removed in 3.6.0.

Fixes #273.﻿