### PR TITLE
Deprecate Retry, for removal in 3.6.0

### DIFF
--- a/reactor-extra/src/main/java/reactor/retry/DefaultRetry.java
+++ b/reactor-extra/src/main/java/reactor/retry/DefaultRetry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,11 @@ import reactor.core.scheduler.Scheduler;
 import reactor.util.Logger;
 import reactor.util.Loggers;
 
+/**
+ * @deprecated To be removed in 3.6.0 at the earliest. Use equivalent features of reactor-core like
+ * {@link reactor.util.retry.RetrySpec} and {@link reactor.util.retry.RetryBackoffSpec} instead.
+ */
+@Deprecated
 public class DefaultRetry<T> extends AbstractRetry<T, Throwable> implements Retry<T> {
 
 	static final Logger log = Loggers.getLogger(DefaultRetry.class);

--- a/reactor-extra/src/main/java/reactor/retry/Retry.java
+++ b/reactor-extra/src/main/java/reactor/retry/Retry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,10 @@ import reactor.core.scheduler.Scheduler;
  * </code></pre>
  *
  * @param <T> Application context type
+ * @deprecated To be removed in 3.6.0 at the earliest. Use equivalent features of reactor-core like
+ * {@link reactor.util.retry.RetrySpec} and {@link reactor.util.retry.RetryBackoffSpec} instead.
  */
+@Deprecated
 public interface Retry<T> extends Function<Flux<Throwable>, Publisher<Long>> {
 
 	/**

--- a/reactor-extra/src/main/java/reactor/retry/RetryContext.java
+++ b/reactor-extra/src/main/java/reactor/retry/RetryContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,10 @@ package reactor.retry;
  * the retry callback {@link Retry#doOnRetry(java.util.function.Consumer)}.
  *
  * @param <T> Application context type
+ * @deprecated To be removed in 3.6.0 at the earliest. Use equivalent features of reactor-core like
+ * {@link reactor.util.retry.RetrySpec} and {@link reactor.util.retry.RetryBackoffSpec} instead.
  */
+@Deprecated
 public interface RetryContext<T> extends IterationContext<T> {
 
 	/**

--- a/reactor-extra/src/main/java/reactor/retry/RetryExhaustedException.java
+++ b/reactor-extra/src/main/java/reactor/retry/RetryExhaustedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,10 @@ package reactor.retry;
  * {@link Retry#timeout(java.time.Duration)} or {@link Retry#retryMax(long)}.
  * For retries, {@link #getCause()} returns the original exception from the
  * last retry attempt that generated this exception.
+ * @deprecated To be removed in 3.6.0 at the earliest. Use equivalent features of reactor-core like
+ * {@link reactor.core.Exceptions#retryExhausted(String, Throwable)} and {@link reactor.core.Exceptions#isRetryExhausted(Throwable)} instead.
  */
+@Deprecated
 public class RetryExhaustedException extends RuntimeException {
 
 	private static final long serialVersionUID = 6961442923363481283L;

--- a/reactor-extra/src/test/java/reactor/retry/AbstractRetryTest.java
+++ b/reactor-extra/src/test/java/reactor/retry/AbstractRetryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2018-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ public class AbstractRetryTest {
             }
         };
 
-        RetryContext<String> retryContext = new DefaultContext<>(null, 1, BackoffDelay.ZERO, null);
+        RepeatContext<String> retryContext = new DefaultContext<>(null, 1, BackoffDelay.ZERO, null);
 
         BackoffDelay backoff = abstractRetry.calculateBackoff(retryContext, timeoutInstant);
         assertThat(backoff)
@@ -106,7 +106,7 @@ public class AbstractRetryTest {
             }
         };
 
-        RetryContext<String> retryContext = new DefaultContext<>(null, 1, BackoffDelay.ZERO, null);
+        RepeatContext<String> retryContext = new DefaultContext<>(null, 1, BackoffDelay.ZERO, null);
 
         BackoffDelay backoff = abstractRetry.calculateBackoff(retryContext, timeoutInstant);
         assertThat(backoff)

--- a/reactor-extra/src/test/java/reactor/retry/DefaultRetryTest.java
+++ b/reactor-extra/src/test/java/reactor/retry/DefaultRetryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Deprecated
 public class DefaultRetryTest {
 
 	@Test

--- a/reactor-extra/src/test/java/reactor/retry/RetryTests.java
+++ b/reactor-extra/src/test/java/reactor/retry/RetryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static reactor.util.retry.Retry.withThrowable;
 
+@Deprecated
 public class RetryTests {
 
 	private Queue<RetryContext<?>> retries = new ConcurrentLinkedQueue<>();


### PR DESCRIPTION
This commit deprecates Retry and associated classes that are not shared
with the sister Repeat utility. While the later doesn't have a core
equivalent yet, Retry is superseded by core's `RetrySpec` (as well as
`RetryBackoffSpec`).

Fixes #278.
