### PR TITLE
Fix exponential Backoff overflow/npe issues by using ms for cap

### DIFF
--- a/reactor-extra/src/main/java/reactor/retry/Backoff.java
+++ b/reactor-extra/src/main/java/reactor/retry/Backoff.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ public interface Backoff extends Function<IterationContext<?>, BackoffDelay> {
 	 * value will be different from the actual exponential value for the iteration.
 	 *
 	 * @param firstBackoff First backoff duration
-	 * @param maxBackoff Maximum backoff duration
+	 * @param maxBackoff Maximum backoff duration, capped to {@link Long#MAX_VALUE} milliseconds
 	 * @param factor The multiplicand for calculating backoff
 	 * @param basedOnPreviousValue If true, calculation is based on previous value which may
 	 *        be a backoff with jitter applied
@@ -86,7 +86,11 @@ public interface Backoff extends Function<IterationContext<?>, BackoffDelay> {
 	static Backoff exponential(Duration firstBackoff, @Nullable Duration maxBackoff, int factor, boolean basedOnPreviousValue) {
 		if (firstBackoff == null || firstBackoff.isNegative() || firstBackoff.isZero())
 			throw new IllegalArgumentException("firstBackoff must be > 0");
-		Duration maxBackoffInterval = maxBackoff != null ? maxBackoff : Duration.ofSeconds(Long.MAX_VALUE);
+		Duration cap = Duration.ofMillis(Long.MAX_VALUE);
+		if (maxBackoff != null && maxBackoff.compareTo(cap) > 0) {
+			throw new IllegalArgumentException("maxBackoff must be less than Long.MAX_VALUE milliseconds");
+		}
+		Duration maxBackoffInterval = maxBackoff != null && maxBackoff.compareTo(cap) < 0 ? maxBackoff : cap;
 		if (maxBackoffInterval.compareTo(firstBackoff) < 0)
 			throw new IllegalArgumentException("maxBackoff must be >= firstBackoff");
 		if (!basedOnPreviousValue) {
@@ -100,6 +104,9 @@ public interface Backoff extends Function<IterationContext<?>, BackoffDelay> {
 					else {
 						try {
 							nextBackoff = firstBackoff.multipliedBy((long) Math.pow(factor, (context.iteration() - 1)));
+							if (nextBackoff.compareTo(maxBackoffInterval) >= 0) {
+								nextBackoff = maxBackoffInterval;
+							}
 						}
 						catch (ArithmeticException e) {
 							nextBackoff = maxBackoffInterval;
@@ -128,12 +135,15 @@ public interface Backoff extends Function<IterationContext<?>, BackoffDelay> {
 					}
 					else try {
 						nextBackoff = prevBackoff.multipliedBy(factor);
+						if (nextBackoff.compareTo(maxBackoffInterval) >= 0) {
+							nextBackoff = maxBackoffInterval;
+						}
 					}
 					catch (ArithmeticException e) {
 						nextBackoff = maxBackoffInterval;
 					}
 					nextBackoff = nextBackoff.compareTo(firstBackoff) < 0 ? firstBackoff : nextBackoff;
-					return new BackoffDelay(firstBackoff, maxBackoff, nextBackoff);
+					return new BackoffDelay(firstBackoff, maxBackoffInterval, nextBackoff);
 				}
 
 				@Override


### PR DESCRIPTION
This commit changes the exponential backoff default maxBackoff to be
Long.MAX_VALUE _milliseconds_ instead of _seconds_. The limit still
represents over 292 million years, plenty enough for a backoff :)

This prevents overflow and arithmetic exceptions, notably when computing
a jitter on top. This upper limit is also enforced in the constructor
when explicitly passing in a `maxBackoff`.

This commit also fixes 2 additional issues:
 - the computed BackoffDelay could have a `delay` component greater than
 the `max`, which would result in a negative jitter higher bound when
 computing the jitter bounds (now prevented in Backoff.exponential)
 - the "depends on previous value" variant would not use the default
 maxBackoffInterval if provided maxBackoff parameter was null, leading
 to a NullPointerException.

Supersedes and closes #269.
