### PR TITLE
Fix BigInteger out of range bug, cause of using long value.

### DIFF
--- a/reactor-extra/src/main/java/reactor/math/MonoAverageBigInteger.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoAverageBigInteger.java
@@ -74,7 +74,8 @@ public class MonoAverageBigInteger<T> extends MonoFromFluxOperator<T, BigInteger
 		@Override
 		protected void updateResult(T newValue) {
 			Number number = mapping.apply(newValue);
-			BigInteger bigIntegerValue = BigInteger.valueOf(number.longValue());
+			BigInteger bigIntegerValue = (number instanceof BigInteger) ?
+					(BigInteger) number : new BigInteger(number.toString());
 			sum = sum.add(bigIntegerValue);
 			count++;
 		}

--- a/reactor-extra/src/main/java/reactor/math/MonoSumBigInteger.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoSumBigInteger.java
@@ -74,7 +74,9 @@ final class MonoSumBigInteger<T> extends MonoFromFluxOperator<T, BigInteger>
 		@Override
 		protected void updateResult(T newValue) {
 			Number number = mapping.apply(newValue);
-			BigInteger bigIntegerValue = BigInteger.valueOf(number.longValue());
+
+			BigInteger bigIntegerValue = (number instanceof BigInteger) ?
+					(BigInteger) number : new BigInteger(number.toString());
 			sum = hasValue ? sum.add(bigIntegerValue) : bigIntegerValue;
 			hasValue = true;
 		}

--- a/reactor-extra/src/main/java/reactor/math/MonoSumBigInteger.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoSumBigInteger.java
@@ -74,7 +74,6 @@ final class MonoSumBigInteger<T> extends MonoFromFluxOperator<T, BigInteger>
 		@Override
 		protected void updateResult(T newValue) {
 			Number number = mapping.apply(newValue);
-
 			BigInteger bigIntegerValue = (number instanceof BigInteger) ?
 					(BigInteger) number : new BigInteger(number.toString());
 			sum = hasValue ? sum.add(bigIntegerValue) : bigIntegerValue;

--- a/reactor-extra/src/test/java/reactor/math/ReactorMathTests.java
+++ b/reactor-extra/src/test/java/reactor/math/ReactorMathTests.java
@@ -178,7 +178,7 @@ public class ReactorMathTests {
 	}
 
 	@Test
-	public void monoBigIntegerRange() {
+	public void noOverflowSumBigInteger() {
 		long longValue = 1100000000000000L;
 		String bigValue = "12319800000000000000";
 		verifyResult(MathFlux.sumBigInteger(Mono.just(BigInteger.valueOf(longValue))), BigInteger.valueOf(longValue));
@@ -186,10 +186,6 @@ public class ReactorMathTests {
 		verifyResult(
 				MathFlux.sumBigInteger(Flux.just(BigInteger.valueOf(longValue), new BigInteger(bigValue, 10))),
 				new BigInteger(bigValue, 10).add(BigInteger.valueOf(longValue))
-		);
-		verifyResult(
-				MathFlux.averageBigInteger(Flux.just(BigInteger.valueOf(longValue), new BigInteger(bigValue, 10))),
-				new BigInteger(bigValue, 10).add(BigInteger.valueOf(longValue)).divide(BigInteger.valueOf(2L))
 		);
 	}
 
@@ -331,6 +327,18 @@ public class ReactorMathTests {
 	@Test
 	public void emptyAverageBigInteger() {
 		verifyEmptyResult(MathFlux.averageBigInteger(Mono.empty()));
+	}
+
+	@Test
+	public void noOverflowAverageBigInteger() {
+		long longValue = 1100000000000000L;
+		String bigValue = "12319800000000000000";
+		verifyResult(MathFlux.averageBigInteger(Mono.just(BigInteger.valueOf(longValue))), BigInteger.valueOf(longValue));
+		verifyResult(MathFlux.averageBigInteger(Mono.just(new BigInteger(bigValue, 10))), new BigInteger(bigValue, 10));
+		verifyResult(
+				MathFlux.averageBigInteger(Flux.just(BigInteger.valueOf(longValue), new BigInteger(bigValue, 10))),
+				new BigInteger(bigValue, 10).add(BigInteger.valueOf(longValue)).divide(BigInteger.valueOf(2L))
+		);
 	}
 
 	@Test

--- a/reactor-extra/src/test/java/reactor/math/ReactorMathTests.java
+++ b/reactor-extra/src/test/java/reactor/math/ReactorMathTests.java
@@ -152,14 +152,10 @@ public class ReactorMathTests {
 				          .multiply(BigInteger.valueOf(2)));
 		verifyResult(MathFlux.sumBigInteger(intFlux(count),
 				i -> i), sum);
-		verifyResult(MathFlux.sumBigInteger(doubleFlux(count),
-				i -> i), sum);
 		verifyResult(MathFlux.sumBigInteger(stringFlux(count), BigInteger::new), sum);
 
 		verifyResult(bigIntegerFlux(count).as(MathFlux::sumBigInteger), sum);
 		verifyResult(bigIntegerFlux(count).transform(MathFlux::sumBigInteger), sum);
-		verifyResult(doubleFlux(count).as(MathFlux::sumBigInteger), sum);
-		verifyResult(doubleFlux(count).transform(MathFlux::sumBigInteger), sum);
 		verifyResult(intFlux(count).as(MathFlux::sumBigInteger), sum);
 		verifyResult(intFlux(count).transform(MathFlux::sumBigInteger), sum);
 	}
@@ -169,7 +165,6 @@ public class ReactorMathTests {
 		verifyResult(MathFlux.sumBigInteger(Mono.just(BigInteger.ONE)), BigInteger.ONE);
 		verifyResult(MathFlux.sumBigInteger(Mono.just("10"), BigInteger::new),
 				BigInteger.TEN);
-		verifyResult(MathFlux.sumBigInteger(Mono.just(1.5)), BigInteger.ONE);
 	}
 
 	@Test
@@ -309,15 +304,13 @@ public class ReactorMathTests {
 		verifyResult(MathFlux.averageBigInteger(stringFlux(count), Long::parseLong),
 				average);
 
-		verifyResult(doubleFlux(count).as(MathFlux::averageBigInteger), average);
-		verifyResult(doubleFlux(count).transform(MathFlux::averageBigInteger), average);
 		verifyResult(intFlux(count).as(MathFlux::averageBigInteger), average);
 		verifyResult(intFlux(count).transform(MathFlux::averageBigInteger), average);
 	}
 
 	@Test
 	public void monoAverageBigInteger() {
-		verifyResult(MathFlux.averageBigInteger(Mono.just(2.5)), BigInteger.valueOf(2));
+		verifyResult(MathFlux.averageBigInteger(Mono.just(2)), BigInteger.valueOf(2));
 		verifyResult(MathFlux.averageBigInteger(Mono.just(2), i -> i),
 				BigInteger.valueOf(2));
 		verifyResult(MathFlux.averageBigInteger(Mono.just("1"), Long::parseLong),

--- a/reactor-extra/src/test/java/reactor/math/ReactorMathTests.java
+++ b/reactor-extra/src/test/java/reactor/math/ReactorMathTests.java
@@ -178,6 +178,22 @@ public class ReactorMathTests {
 	}
 
 	@Test
+	public void monoBigIntegerRange() {
+		long longValue = 1100000000000000L;
+		String bigValue = "12319800000000000000";
+		verifyResult(MathFlux.sumBigInteger(Mono.just(BigInteger.valueOf(longValue))), BigInteger.valueOf(longValue));
+		verifyResult(MathFlux.sumBigInteger(Mono.just(new BigInteger(bigValue, 10))), new BigInteger(bigValue, 10));
+		verifyResult(
+				MathFlux.sumBigInteger(Flux.just(BigInteger.valueOf(longValue), new BigInteger(bigValue, 10))),
+				new BigInteger(bigValue, 10).add(BigInteger.valueOf(longValue))
+		);
+		verifyResult(
+				MathFlux.averageBigInteger(Flux.just(BigInteger.valueOf(longValue), new BigInteger(bigValue, 10))),
+				new BigInteger(bigValue, 10).add(BigInteger.valueOf(longValue)).divide(BigInteger.valueOf(2L))
+		);
+	}
+
+	@Test
 	public void fluxSumBigDecimal() {
 		int count = 10;
 		BigDecimal sumDouble = BigDecimal.valueOf(Double.valueOf(sum(count)));


### PR DESCRIPTION
Previous version use number.longValue, and may be out of range, use String to fix it just like BigDecimal.