### PR TITLE
Improve averageBigInteger and sumBigInteger precision/conversion

### DIFF
--- a/reactor-extra/src/main/java/reactor/math/MathFlux.java
+++ b/reactor-extra/src/main/java/reactor/math/MathFlux.java
@@ -143,6 +143,10 @@ public final class MathFlux {
 
 	/**
 	 * Computes the {@link BigInteger} sum of items in the source.
+	 * <p>
+	 * Further conversion of individual elements to {@link BigDecimal} is always applied to
+	 * retain maximum precision. When the sum is ultimately produced, it can be rounded or
+	 * truncated as a {@link BigDecimal#toBigInteger()} final conversion is applied.
 	 *
 	 * @param source the numerical source
 	 * @return {@link Mono} of the sum of items in source
@@ -154,6 +158,10 @@ public final class MathFlux {
 	/**
 	 * Computes the {@link BigInteger} sum of items in the source, which are mapped to
 	 * numerical values using provided mapping.
+	 * <p>
+	 * Further conversion of individual elements to {@link BigDecimal} is always applied to
+	 * retain maximum precision. When the sum is ultimately produced, it can be rounded or
+	 * truncated as a {@link BigDecimal#toBigInteger()} final conversion is applied.
 	 *
 	 * @param source  the source items
 	 * @param mapping a function to map source items to numerical values
@@ -237,6 +245,11 @@ public final class MathFlux {
 
 	/**
 	 * Computes the {@link BigInteger} average of items in the source.
+	 * <p>
+	 * The average is computed by summing {@link BigDecimal}-converted values and ultimately
+	 * dividing that number by the number of elements. Eventually the result of that division
+	 * can be rounded or truncated, as the {@link java.math.RoundingMode#FLOOR FLOOR rounding mode}
+	 * is applied and the {@link BigDecimal#toBigInteger()} final conversion is performed.
 	 *
 	 * @param source the numerical source
 	 * @return {@link Mono} of the average of items in source
@@ -248,6 +261,12 @@ public final class MathFlux {
 	/**
 	 * Computes the {@link BigInteger} average of items in the source, which are mapped to
 	 * numerical values using the provided mapping.
+	 * <p>
+	 * Further conversion of individual elements to {@link BigDecimal} is always applied.
+	 * The average is computed by summing {@link BigDecimal}-converted values and ultimately
+	 * dividing that number by the number of elements. Eventually the result of that division
+	 * can be rounded or truncated, as the {@link java.math.RoundingMode#FLOOR FLOOR rounding mode}
+	 * is applied and the {@link BigDecimal#toBigInteger()} final conversion is performed.
 	 *
 	 * @param source  the source items
 	 * @param mapping a function to map source items to numerical values
@@ -255,7 +274,7 @@ public final class MathFlux {
 	 */
 	public static final <T> Mono<BigInteger> averageBigInteger(Publisher<T> source,
 			Function<? super T, ? extends Number> mapping) {
-		return MathMono.onAssembly(new MonoAverageBigInteger<T>(source, mapping));
+		return MathMono.onAssembly(new MonoAverageBigInteger<>(source, mapping));
 	}
 
 

--- a/reactor-extra/src/main/java/reactor/math/MonoSumBigInteger.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoSumBigInteger.java
@@ -16,6 +16,7 @@
 
 package reactor.math;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.function.Function;
 
@@ -50,7 +51,7 @@ final class MonoSumBigInteger<T> extends MonoFromFluxOperator<T, BigInteger>
 
 		private final Function<? super T, ? extends Number> mapping;
 
-		BigInteger sum;
+		BigDecimal sum;
 
 		boolean hasValue;
 
@@ -62,20 +63,29 @@ final class MonoSumBigInteger<T> extends MonoFromFluxOperator<T, BigInteger>
 
 		@Override
 		protected void reset() {
-			sum = BigInteger.ZERO;
+			sum = BigDecimal.ZERO;
 			hasValue = false;
 		}
 
 		@Override
 		protected BigInteger result() {
-			return (hasValue ? sum : null);
+			return (hasValue ? sum.toBigInteger() : null);
 		}
 
 		@Override
 		protected void updateResult(T newValue) {
 			Number number = mapping.apply(newValue);
-			BigInteger bigIntegerValue = BigInteger.valueOf(number.longValue());
-			sum = hasValue ? sum.add(bigIntegerValue) : bigIntegerValue;
+			BigDecimal bigDecimalValue;
+			if (number instanceof BigDecimal) {
+				bigDecimalValue = (BigDecimal) number;
+			}
+			else if (number instanceof BigInteger) {
+				bigDecimalValue = new BigDecimal((BigInteger) number);
+			}
+			else {
+				bigDecimalValue = new BigDecimal(number.toString());
+			}
+			sum = hasValue ? sum.add(bigDecimalValue) : bigDecimalValue;
 			hasValue = true;
 		}
 	}


### PR DESCRIPTION
This commit improves the precision and conversion behavior of `MathFlux`
`sumBigInteger` and `averageBigInteger` methods. These method better deal with
fractional types by internally summing using a `BigDecimal` rather than a
`BigInteger`. As a result, the only lossy step is at the end when the result is
effectively presented as a `BigInteger`: 
 - `sum`: remaining fractional part of the BigDecimal sum is dropped
 - `average`: the division by `count` is applied, then the result's fractional
 part is dropped

Previously the fractional part would be progressively dropped by implicit
conversion of each incoming element to `long`.

Similar to precision improvement done in #260/#261 and earlier iteration done
in #284.