### PR TITLE
release hotfix: Adapt to MonoSubscriber not fusing by default

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-reactorCore = "3.4.18-SNAPSHOT"
+reactorCore = "3.4.25-SNAPSHOT"
 # Other shared versions
 kotlin = "1.5.32"
 reactiveStreams = "1.0.3"

--- a/reactor-adapter/src/main/java/reactor/adapter/rxjava/RxJava3Adapter.java
+++ b/reactor-adapter/src/main/java/reactor/adapter/rxjava/RxJava3Adapter.java
@@ -776,6 +776,7 @@ public abstract class RxJava3Adapter {
             source.subscribe(new MaybeAsMonoObserver<>(s));
         }
 
+        //FIXME this and all other MonoSubscriber-extending classes are fake-fuseable: requestFusion will always reply NONE unless overridden
         static final class MaybeAsMonoObserver<T> extends MonoSubscriber<T, T> implements MaybeObserver<T> {
 
             io.reactivex.rxjava3.disposables.Disposable d;

--- a/reactor-adapter/src/test/java/reactor/adapter/rxjava/RxJava2AdapterTest.java
+++ b/reactor-adapter/src/test/java/reactor/adapter/rxjava/RxJava2AdapterTest.java
@@ -117,19 +117,8 @@ public class RxJava2AdapterTest {
 	                .expectComplete()
 	                .verify();
     }
+	//NB: MonoSubscribers like SingleToMonoSubscriber are not fuseable anymore
 
-    @Test
-    public void singleToMonoFused() {
-	    Mono<Integer> m = Single.just(1)
-	                            .to(RxJava2Adapter::singleToMono);
-
-	    StepVerifier.create(m)
-	                .expectFusion(Fuseable.ANY, Fuseable.ASYNC)
-	                .expectNext(1)
-	                .expectComplete()
-	                .verify();
-    }
-    
     @Test
     public void monoToSingle() {
         Mono.just(1)
@@ -233,14 +222,6 @@ public class RxJava2AdapterTest {
 	                .expectErrorMessage("Forced failure")
 	                .verify();
     }
+	//NB: MonoSubscribers like MaybeToMonoSubscriber are not fuseable anymore
 
-    @Test
-    public void maybeToMonoEmptyFused() {
-	    Mono<Void> m = Maybe.<Void>empty().to(RxJava2Adapter::maybeToMono);
-
-	    StepVerifier.create(m)
-	                .expectFusion(Fuseable.ANY, Fuseable.ASYNC)
-	                .expectComplete()
-	                .verify();
-    }
 }

--- a/reactor-adapter/src/test/java/reactor/adapter/rxjava/RxJava3AdapterTest.java
+++ b/reactor-adapter/src/test/java/reactor/adapter/rxjava/RxJava3AdapterTest.java
@@ -204,16 +204,7 @@ public class RxJava3AdapterTest {
 		            .expectComplete()
 		            .verify();
 	}
-
-	@Test
-	public void maybeToMonoEmptyFused() {
-		Mono<Void> m = Maybe.<Void>empty().to(RxJava3Adapter::maybeToMono);
-
-		StepVerifier.create(m)
-		            .expectFusion(Fuseable.ANY, Fuseable.ASYNC)
-		            .expectComplete()
-		            .verify();
-	}
+	//NB: MonoSubscribers like MaybeToMonoSubscriber are not fuseable anymore
 
 	@Test
 	public void maybeToMonoError() {
@@ -312,19 +303,7 @@ public class RxJava3AdapterTest {
 		            .expectComplete()
 		            .verify();
 	}
-
-	@Test
-	public void singleToMonoFused() {
-		Mono<Integer> m = Single.just(1)
-		                        .to(RxJava3Adapter::singleToMono);
-
-		StepVerifier.create(m)
-		            .expectFusion(Fuseable.ANY, Fuseable.ASYNC)
-		            .expectNext(1)
-		            .expectComplete()
-		            .verify();
-	}
-
+	//NB: MonoSubscribers like SingleToMonoSubscriber are not fuseable anymore
 
 	@Test
 	public void scheduler() {


### PR DESCRIPTION
In reactor-core, `Operators.MonoSubscriber` has stopped implementing
ASYNC fusion as a base. It continues to be compatible with Fuseable
publishers but now by default only negotiates `Fuseable.NONE`.

Some RxJava adapter classes don't really have a way of propagating the
fusion up to RxJava and used to rely on the default ASYNC capability
of MonoSubscriber, testing that `requestFusion` would indeed negotiate
that. Now that it negotiates NONE, said tests fail.

This commit removes the tests and adds a FIXME as a more in depth follow
up to this issue (where we can evaluate if it makes sense to keep the
publishers Fuseable).

Also update to latest 3.4.x core snapshot.

See reactor/reactor-core#3245.