### PR TITLE
Fix math operators with lifting and context propagation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -235,6 +235,7 @@ project('reactor-extra') {
 		testImplementation getSwtPlatform()
 		testImplementation libs.reactiveStreams.tck
 		testImplementation libs.mockito
+		testRuntimeOnly libs.contextPropagation
 	}
 
   jar {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ reactiveStreams = "1.0.4"
 swt = "4.5.2"
 
 [libraries]
+contextPropagation = "io.micrometer:context-propagation:1.2.1"
 reactorCore = { module = "io.projectreactor:reactor-core", version.ref = "reactorCore" }
 reactorTest = { module = "io.projectreactor:reactor-test", version.ref = "reactorCore" }
 akkaActor = "com.typesafe.akka:akka-actor_2.11:2.4.10"

--- a/reactor-extra/src/main/java/reactor/math/MonoAverageBigDecimal.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoAverageBigDecimal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import java.util.function.Function;
 import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Publisher;
 import reactor.core.CoreSubscriber;
-import reactor.core.Fuseable;
 import reactor.core.publisher.Flux;
 
 /**
@@ -31,8 +30,7 @@ import reactor.core.publisher.Flux;
  *
  * @param <T> the input value type
  */
-public class MonoAverageBigDecimal<T> extends MonoFromFluxOperator<T, BigDecimal>
-		implements Fuseable {
+public class MonoAverageBigDecimal<T> extends MonoFromFluxOperator<T, BigDecimal> {
 
 	private final Function<? super T, ? extends Number> mapping;
 

--- a/reactor-extra/src/main/java/reactor/math/MonoAverageBigInteger.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoAverageBigInteger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import java.util.function.Function;
 import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Publisher;
 import reactor.core.CoreSubscriber;
-import reactor.core.Fuseable;
 import reactor.core.publisher.Flux;
 
 /**
@@ -32,8 +31,7 @@ import reactor.core.publisher.Flux;
  *
  * @param <T> the input value type
  */
-public class MonoAverageBigInteger<T> extends MonoFromFluxOperator<T, BigInteger>
-		implements Fuseable {
+public class MonoAverageBigInteger<T> extends MonoFromFluxOperator<T, BigInteger> {
 
 	private final Function<? super T, ? extends Number> mapping;
 

--- a/reactor-extra/src/main/java/reactor/math/MonoAverageDouble.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoAverageDouble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import java.util.function.Function;
 import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Publisher;
 import reactor.core.CoreSubscriber;
-import reactor.core.Fuseable;
 import reactor.core.publisher.Flux;
 
 /**
@@ -29,7 +28,7 @@ import reactor.core.publisher.Flux;
  *
  * @param <T> the input value type
  */
-final class MonoAverageDouble<T> extends MonoFromFluxOperator<T, Double> implements Fuseable {
+final class MonoAverageDouble<T> extends MonoFromFluxOperator<T, Double> {
 
 	final Function<? super T, ? extends Number> mapping;
 

--- a/reactor-extra/src/main/java/reactor/math/MonoAverageFloat.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoAverageFloat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import java.util.function.Function;
 import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Publisher;
 import reactor.core.CoreSubscriber;
-import reactor.core.Fuseable;
 import reactor.core.publisher.Flux;
 
 /**
@@ -29,7 +28,7 @@ import reactor.core.publisher.Flux;
  *
  * @param <T> the input value type
  */
-final class MonoAverageFloat<T> extends MonoFromFluxOperator<T, Float> implements Fuseable {
+final class MonoAverageFloat<T> extends MonoFromFluxOperator<T, Float> {
 
 	final Function<? super T, ? extends Number> mapping;
 

--- a/reactor-extra/src/main/java/reactor/math/MonoMinMax.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoMinMax.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import java.util.Comparator;
 import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Publisher;
 import reactor.core.CoreSubscriber;
-import reactor.core.Fuseable;
 import reactor.core.publisher.Flux;
 
 /**
@@ -29,7 +28,7 @@ import reactor.core.publisher.Flux;
  *
  * @param <T> the input value type
  */
-final class MonoMinMax<T> extends MonoFromFluxOperator<T, T> implements Fuseable {
+final class MonoMinMax<T> extends MonoFromFluxOperator<T, T> {
 
 	final Comparator<? super T> comparator;
 

--- a/reactor-extra/src/main/java/reactor/math/MonoSumBigDecimal.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoSumBigDecimal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import java.util.function.Function;
 import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Publisher;
 import reactor.core.CoreSubscriber;
-import reactor.core.Fuseable;
 import reactor.core.publisher.Flux;
 
 /**
@@ -30,8 +29,7 @@ import reactor.core.publisher.Flux;
  *
  * @param <T> the input value type
  */
-public class MonoSumBigDecimal<T> extends MonoFromFluxOperator<T, BigDecimal>
-		implements Fuseable {
+public class MonoSumBigDecimal<T> extends MonoFromFluxOperator<T, BigDecimal> {
 
 	private final Function<? super T, ? extends Number> mapping;
 

--- a/reactor-extra/src/main/java/reactor/math/MonoSumBigInteger.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoSumBigInteger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import java.util.function.Function;
 import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Publisher;
 import reactor.core.CoreSubscriber;
-import reactor.core.Fuseable;
 import reactor.core.publisher.Flux;
 
 /**
@@ -31,8 +30,7 @@ import reactor.core.publisher.Flux;
  *
  * @param <T> the input value type
  */
-final class MonoSumBigInteger<T> extends MonoFromFluxOperator<T, BigInteger>
-		implements Fuseable {
+final class MonoSumBigInteger<T> extends MonoFromFluxOperator<T, BigInteger> {
 
 	private final Function<? super T, ? extends Number> mapping;
 

--- a/reactor-extra/src/main/java/reactor/math/MonoSumDouble.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoSumDouble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import java.util.function.Function;
 import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Publisher;
 import reactor.core.CoreSubscriber;
-import reactor.core.Fuseable;
 import reactor.core.publisher.Flux;
 
 /**
@@ -29,7 +28,7 @@ import reactor.core.publisher.Flux;
  *
  * @param <T> the input value type
  */
-final class MonoSumDouble<T> extends MonoFromFluxOperator<T, Double> implements Fuseable {
+final class MonoSumDouble<T> extends MonoFromFluxOperator<T, Double> {
 
 	final Function<? super T, ? extends Number> mapping;
 

--- a/reactor-extra/src/main/java/reactor/math/MonoSumFloat.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoSumFloat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import java.util.function.Function;
 import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Publisher;
 import reactor.core.CoreSubscriber;
-import reactor.core.Fuseable;
 import reactor.core.publisher.Flux;
 
 /**
@@ -29,7 +28,7 @@ import reactor.core.publisher.Flux;
  *
  * @param <T> the input value type
  */
-final class MonoSumFloat<T> extends MonoFromFluxOperator<T, Float> implements Fuseable {
+final class MonoSumFloat<T> extends MonoFromFluxOperator<T, Float> {
 
 	final Function<? super T, ? extends Number> mapping;
 

--- a/reactor-extra/src/main/java/reactor/math/MonoSumInt.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoSumInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import java.util.function.Function;
 import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Publisher;
 import reactor.core.CoreSubscriber;
-import reactor.core.Fuseable;
 import reactor.core.publisher.Flux;
 
 /**
@@ -29,7 +28,7 @@ import reactor.core.publisher.Flux;
  *
  * @param <T> the input value type
  */
-final class MonoSumInt<T> extends MonoFromFluxOperator<T, Integer> implements Fuseable {
+final class MonoSumInt<T> extends MonoFromFluxOperator<T, Integer> {
 
 	final Function<? super T, ? extends Number> mapping;
 

--- a/reactor-extra/src/main/java/reactor/math/MonoSumLong.java
+++ b/reactor-extra/src/main/java/reactor/math/MonoSumLong.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2025 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2017-2026 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import java.util.function.Function;
 import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Publisher;
 import reactor.core.CoreSubscriber;
-import reactor.core.Fuseable;
 import reactor.core.publisher.Flux;
 
 /**
@@ -29,7 +28,7 @@ import reactor.core.publisher.Flux;
  *
  * @param <T> the input value type
  */
-final class MonoSumLong<T> extends MonoFromFluxOperator<T, Long> implements Fuseable {
+final class MonoSumLong<T> extends MonoFromFluxOperator<T, Long> {
 
 	final Function<? super T, ? extends Number> mapping;
 

--- a/reactor-extra/src/test/java/reactor/math/MathContextPropagationTests.java
+++ b/reactor-extra/src/test/java/reactor/math/MathContextPropagationTests.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 VMware Inc. or its affiliates, All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reactor.math;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.function.Function;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Hooks;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Operators;
+import reactor.test.StepVerifier;
+import reactor.test.publisher.TestPublisher;
+
+@RunWith(Parameterized.class)
+public class MathContextPropagationTests {
+
+	@Parameterized.Parameters(name = "{0}")
+	public static Collection<Object[]> operators() {
+		return Arrays.asList(new Object[][] {
+				{"sumInt", (Function<Flux<Integer>, Mono<?>>) MathFlux::sumInt, 6},
+				{"sumLong", (Function<Flux<Integer>, Mono<?>>) MathFlux::sumLong, 6L},
+				{"sumFloat", (Function<Flux<Integer>, Mono<?>>) MathFlux::sumFloat, 6F},
+				{"sumDouble", (Function<Flux<Integer>, Mono<?>>) MathFlux::sumDouble, 6D},
+				{"sumBigInteger", (Function<Flux<Integer>, Mono<?>>)
+						values -> MathFlux.sumBigInteger(values, value -> BigInteger.valueOf(value.longValue())), BigInteger.valueOf(6)},
+				{"sumBigDecimal", (Function<Flux<Integer>, Mono<?>>)
+						values -> MathFlux.sumBigDecimal(values, value -> BigDecimal.valueOf(value.longValue())), BigDecimal.valueOf(6)},
+				{"averageFloat", (Function<Flux<Integer>, Mono<?>>) MathFlux::averageFloat, 2F},
+				{"averageDouble", (Function<Flux<Integer>, Mono<?>>) MathFlux::averageDouble, 2D},
+				{"averageBigInteger", (Function<Flux<Integer>, Mono<?>>)
+						values -> MathFlux.averageBigInteger(values, value -> BigInteger.valueOf(value.longValue())), BigInteger.valueOf(2)},
+				{"averageBigDecimal", (Function<Flux<Integer>, Mono<?>>)
+						values -> MathFlux.averageBigDecimal(values, value -> BigDecimal.valueOf(value.longValue())), BigDecimal.valueOf(2)},
+				{"min", (Function<Flux<Integer>, Mono<?>>) MathFlux::min, 1},
+				{"max", (Function<Flux<Integer>, Mono<?>>) MathFlux::max, 3}
+		});
+	}
+
+	private final Function<Flux<Integer>, Mono<?>> operator;
+	private final Object expected;
+
+	public MathContextPropagationTests(String name, Function<Flux<Integer>, Mono<?>> operator, Object expected) {
+		this.operator = operator;
+		this.expected = expected;
+	}
+
+	@Before
+	public void enableContextPropagation() {
+		Hooks.onEachOperator("mathTracing", Operators.lift(
+				scannable -> scannable instanceof MonoFromFluxOperator,
+				(scannable, subscriber) -> subscriber));
+		Hooks.enableAutomaticContextPropagation();
+	}
+
+	@After
+	public void resetHooks() {
+		Hooks.disableAutomaticContextPropagation();
+		Hooks.resetOnEachOperator("mathTracing");
+	}
+
+	@Test
+	public void mappedResult() {
+		StepVerifier.create(this.operator.apply(Flux.just(1, 2, 3)).flux().map(Object::toString))
+				.expectNext(this.expected.toString())
+				.verifyComplete();
+	}
+
+	@Test
+	public void conditionalResultWithDeferredDemand() {
+		StepVerifier.create(this.operator.apply(Flux.just(1, 2, 3)).flux()
+				.map(Object::toString).filter(value -> !value.isEmpty()), 0)
+				.thenRequest(1)
+				.expectNext(this.expected.toString())
+				.verifyComplete();
+	}
+
+	@Test
+	public void emptySource() {
+		StepVerifier.create(this.operator.apply(Flux.empty()).flux().map(Object::toString))
+				.verifyComplete();
+	}
+
+	@Test
+	public void sourceError() {
+		IllegalStateException failure = new IllegalStateException("source failure");
+		StepVerifier.create(this.operator.apply(Flux.error(failure)).flux().map(Object::toString))
+				.verifyErrorMatches(error -> error == failure);
+	}
+
+	@Test
+	public void cancellation() {
+		TestPublisher<Integer> source = TestPublisher.create();
+		StepVerifier.create(this.operator.apply(source.flux()).flux().map(Object::toString))
+				.thenCancel()
+				.verify();
+		source.assertCancelled();
+	}
+}


### PR DESCRIPTION
Math operators can fail with ClassCastException when operator lifting and automatic context propagation are combined. Their Fuseable marker causes downstream operators to expect a QueueSubscription across a context-restoring wrapper that does not provide one.

Remove the marker from the sum, average, min, and max operators. Their shared MonoSubscriber already negotiates Fuseable.NONE, so this does not remove an existing fusion optimization. MathFlux method signatures and aggregation behavior remain unchanged.

Add regression coverage for all 12 math families with selective lifting, downstream mapping/filtering, deferred demand, empty/error sources, and cancellation. The original WebFlux reproducer changes from HTTP 500 to HTTP 200 with the expected result.

Validation:
- ./gradlew check javadoc --no-build-cache --rerun-tasks on Java 21
- ./gradlew check --offline --no-build-cache --rerun-tasks on Java 8

Both runs pass: 305 total tests, including one existing disabled SWT test.

Fixes #362.